### PR TITLE
feat: add objective-c wrapper

### DIFF
--- a/.github/workflows/ci-obj-c.yml
+++ b/.github/workflows/ci-obj-c.yml
@@ -1,4 +1,4 @@
-name: obj-c-ci
+name: ci-obj-c
 
 on:
   pull_request:
@@ -24,7 +24,7 @@ jobs:
         run: yarn build:ios
 
       - name: Update binary for wrapper
-        run: cp out/ios/universal/libbbs.a wrappers/obj-c/libraries/libbbs.a
+        run: yarn wrapper:obj-c:update-binary
 
       - name: Build and test wrapper
         run: yarn wrapper:obj-c:build

--- a/.github/workflows/obj-c-ci.yml
+++ b/.github/workflows/obj-c-ci.yml
@@ -24,7 +24,7 @@ jobs:
         run: yarn build:ios
 
       - name: Update binary for wrapper
-        run: cp out/ios wrappers/obj-c/libraries
+        run: cp out/ios/universal/libbbs.a wrappers/obj-c/libraries/libbbs.a
 
       - name: Build and test wrapper
         run: yarn wrapper:obj-c:build

--- a/.github/workflows/obj-c-ci.yml
+++ b/.github/workflows/obj-c-ci.yml
@@ -1,0 +1,30 @@
+name: obj-c-ci
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
+jobs:
+  build_test:
+    name: Build & Test Objective-C Wrapper
+    if: "! contains(github.event.head_commit.message, '[skip ci]')"
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Install Dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build binary for IOS
+        run: yarn build:ios
+
+      - name: Update binary for wrapper
+        run: cp out/ios wrappers/obj-c/libraries
+
+      - name: Build and test wrapper
+        run: yarn wrapper:obj-c:build

--- a/README.md
+++ b/README.md
@@ -22,3 +22,34 @@ prover.
 
 Every release of this repository publishes a new [github release](https://github.com/mattrglobal/ffi-bbs-signatures/releases/tag/v0.1.0) including publishing the platform specific artifacts required to run the library in different environments. See the [release process](./docs/RELEASE.md) for
 more details on this process
+
+# Getting started
+
+This repository makes use of [Yarn](https://yarnpkg.com/) to manage the dependencies related to the development environment
+
+To install the development dependencies run
+
+```
+yarn install --frozen-lockfile
+``
+
+To build the library for all available platforms run
+
+```
+
+yarn build
+
+```
+
+To build a particular wrapper run
+
+```
+
+yarn wrappers:<name-of-wrapper>:build
+
+```
+
+Where the available wrappers are
+
+- obj-c => Objective-C wrapper
+```

--- a/README.md
+++ b/README.md
@@ -31,25 +31,22 @@ To install the development dependencies run
 
 ```
 yarn install --frozen-lockfile
-``
+```
 
 To build the library for all available platforms run
 
 ```
-
 yarn build
-
 ```
 
 To build a particular wrapper run
 
 ```
-
 yarn wrappers:<name-of-wrapper>:build
-
 ```
 
 Where the available wrappers are
 
 - obj-c => Objective-C wrapper
-```
+
+**Note** The dotnet wrapper has its own build process documented [here](./wrappers/dotnet/README.md)

--- a/bbs-signatures.podspec
+++ b/bbs-signatures.podspec
@@ -1,0 +1,31 @@
+require "json"
+
+# TODO change it so the version of this is managed from the package.json
+Pod::Spec.new do |s|
+  s.name         = "bbs-signatures"
+  s.version      = "0.1.0"
+  s.authors      = "MATTR"
+  s.license      = { :type => 'Apache 2.0'}
+  s.homepage     = "https://github.com/mattrglobal/ffi-bbs-signatures"
+  s.summary      = "A objective-c wrapper for BBS+ signatures"
+
+  s.platforms    = { :ios => "9.0" }
+  s.source       = { :git => "https://github.com/mattrglobal/ffi-bbs-signatures.git", :tag => "#{s.version}" }
+
+  s.vendored_libraries = 'wrappers/obj-c/libraries/libbbs.a'
+  s.libraries = 'bbs'
+  s.source_files = 'wrappers/obj-c/bbs-signatures/*.{h,m,mm}'
+  s.requires_arc = true
+
+  s.pod_target_xcconfig = {
+    'VALID_ARCHS' => 'arm64 x86_64',
+    "HEADER_SEARCH_PATHS" => "$(CONFIGURATION_BUILD_DIR)",
+    "ENABLE_BITCODE" => "NO"
+  }
+
+  s.user_target_xcconfig = { 'VALID_ARCHS' => 'arm64 x86_64' }
+
+  s.test_spec 'Tests' do |test_spec|
+    test_spec.source_files = 'wrappers/obj-c/tests/*.{h,m}'
+  end
+end

--- a/bbs-signatures.podspec
+++ b/bbs-signatures.podspec
@@ -1,13 +1,14 @@
 require "json"
 
-# TODO change it so the version of this is managed from the package.json
+package = JSON.parse(File.read(File.join(__dir__, "package.json")))
+
 Pod::Spec.new do |s|
   s.name         = "bbs-signatures"
-  s.version      = "0.1.0"
-  s.authors      = "MATTR"
-  s.license      = { :type => 'Apache 2.0'}
-  s.homepage     = "https://github.com/mattrglobal/ffi-bbs-signatures"
-  s.summary      = "A objective-c wrapper for BBS+ signatures"
+  s.version      = package["version"]
+  s.summary      = package["description"]
+  s.homepage     = package["homepage"]
+  s.license      = package["license"]
+  s.authors      = package["author"]
 
   s.platforms    = { :ios => "9.0" }
   s.source       = { :git => "https://github.com/mattrglobal/ffi-bbs-signatures.git", :tag => "#{s.version}" }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "ffi-bbs-signatures",
+  "author": "MATTR",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/mattrglobal/ffi-bbs-signatures",
   "title": "An FFI Wrapper for BBS Signatures",
+  "description": "An FFI Wrapper for BBS Signatures",
   "version": "0.1.0",
   "scripts": {
     "install": "./scripts/install-dependencies.sh",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,9 @@
     "build": "yarn build:ios && yarn build:android",
     "build:ios": "mkdir -p ./out && ./scripts/build.sh IOS ./out",
     "build:android": "mkdir -p ./out && ./scripts/build.sh ANDROID ./out",
-    "wrapper:obj-c:build": "pod lib lint --allow-warnings",
     "test": "make test",
+    "wrapper:obj-c:build": "pod lib lint --allow-warnings",
+    "wrapper:obj-c:update-binary": "yarn build:ios && cp out/ios/universal/libbbs.a wrappers/obj-c/libraries/libbbs.a",
     "version": "conventional-changelog -p angular -i CHANGELOG.md -s && git add CHANGELOG.md",
     "release:prepare": "./scripts/prepare-release-artifacts.sh",
     "version:release": "yarn version --minor --message \"chore(release): publish [skip ci]\""

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build": "yarn build:ios && yarn build:android",
     "build:ios": "mkdir -p ./out && ./scripts/build.sh IOS ./out",
     "build:android": "mkdir -p ./out && ./scripts/build.sh ANDROID ./out",
+    "wrapper:obj-c:build": "pod lib lint --allow-warnings",
     "test": "make test",
     "version": "conventional-changelog -p angular -i CHANGELOG.md -s && git add CHANGELOG.md",
     "release:prepare": "./scripts/prepare-release-artifacts.sh",

--- a/wrappers/obj-c/.gitignore
+++ b/wrappers/obj-c/.gitignore
@@ -1,0 +1,170 @@
+
+# Created by https://www.toptal.com/developers/gitignore/api/swift,xcode,objective-c,osx
+# Edit at https://www.toptal.com/developers/gitignore?templates=swift,xcode,objective-c,osx
+
+### Objective-C ###
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## User settings
+xcuserdata/
+
+## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
+*.xcscmblueprint
+*.xccheckout
+
+## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
+build/
+DerivedData/
+*.moved-aside
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+
+## Obj-C/Swift specific
+*.hmap
+
+## App packaging
+*.ipa
+*.dSYM.zip
+*.dSYM
+
+# CocoaPods
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+# Pods/
+# Add this line if you want to avoid checking in source code from the Xcode workspace
+# *.xcworkspace
+
+# Carthage
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build/
+
+# fastlane
+# It is recommended to not store the screenshots in the git repo.
+# Instead, use fastlane to re-generate the screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://docs.fastlane.tools/best-practices/source-control/#source-control
+
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots/**/*.png
+fastlane/test_output
+
+# Code Injection
+# After new code Injection tools there's a generated folder /iOSInjectionProject
+# https://github.com/johnno1962/injectionforxcode
+
+iOSInjectionProject/
+
+### Objective-C Patch ###
+
+### OSX ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Swift ###
+# Xcode
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+
+
+
+
+
+## Playgrounds
+timeline.xctimeline
+playground.xcworkspace
+
+# Swift Package Manager
+# Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
+# Packages/
+# Package.pins
+# Package.resolved
+# *.xcodeproj
+# Xcode automatically generates this directory with a .xcworkspacedata file and xcuserdata
+# hence it is not needed unless you have added a package configuration file to your project
+# .swiftpm
+
+.build/
+
+# CocoaPods
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+# Pods/
+# Add this line if you want to avoid checking in source code from the Xcode workspace
+# *.xcworkspace
+
+# Carthage
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+
+# Accio dependency management
+Dependencies/
+.accio/
+
+# fastlane
+# It is recommended to not store the screenshots in the git repo.
+# Instead, use fastlane to re-generate the screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://docs.fastlane.tools/best-practices/source-control/#source-control
+
+
+# Code Injection
+# After new code Injection tools there's a generated folder /iOSInjectionProject
+# https://github.com/johnno1962/injectionforxcode
+
+
+### Xcode ###
+# Xcode
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+
+
+
+## Gcc Patch
+/*.gcno
+
+### Xcode Patch ###
+*.xcodeproj/*
+!*.xcodeproj/project.pbxproj
+!*.xcodeproj/xcshareddata/
+!*.xcworkspace/contents.xcworkspacedata
+**/xcshareddata/WorkspaceSettings.xcsettings
+
+# End of https://www.toptal.com/developers/gitignore/api/swift,xcode,objective-c,osx

--- a/wrappers/obj-c/README.md
+++ b/wrappers/obj-c/README.md
@@ -2,13 +2,11 @@
 
 # Building
 
-From the root of the repository run
+From the root of the repository after setting up the [development toolchain](../../README.md) run
 
 ```
-pod lib lint
+yarn wrapper:obj-c:build
 ```
-
-If you encounter an error run with the `--verbose` flag
 
 # Supported Architectures
 

--- a/wrappers/obj-c/README.md
+++ b/wrappers/obj-c/README.md
@@ -1,0 +1,15 @@
+# Objective C Wrapper for bbs-signatures
+
+# Building
+
+From the root of the repository run
+
+```
+pod lib lint
+```
+
+If you encounter an error run with the `--verbose` flag
+
+# Supported Architectures
+
+Due to rust ending support for 32bit targets this pod only works with `x86_64` and `arm64` see [here](https://blog.rust-lang.org/2020/01/03/reducing-support-for-32-bit-apple-targets.html) for more details.

--- a/wrappers/obj-c/bbs-signatures.xcodeproj/project.pbxproj
+++ b/wrappers/obj-c/bbs-signatures.xcodeproj/project.pbxproj
@@ -1,0 +1,512 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		9309BC3524FDF470004B1B6E /* bls12381g2_key_pair.m in Sources */ = {isa = PBXBuildFile; fileRef = 9309BC3424FDF470004B1B6E /* bls12381g2_key_pair.m */; };
+		9309BC3624FDF470004B1B6E /* bls12381g2_key_pair.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9309BC3324FDF470004B1B6E /* bls12381g2_key_pair.h */; };
+		9309BC4424FDFE45004B1B6E /* bls12381g2_key_pair.m in Sources */ = {isa = PBXBuildFile; fileRef = 9309BC4324FDFE45004B1B6E /* bls12381g2_key_pair.m */; };
+		9309BC4624FDFE45004B1B6E /* libbbs-signatures.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9309BC3024FDF470004B1B6E /* libbbs-signatures.a */; };
+		935A71AE24FF05F10083FC6D /* bbs_key_pair.m in Sources */ = {isa = PBXBuildFile; fileRef = 935A71AD24FF05F10083FC6D /* bbs_key_pair.m */; };
+		9387DA0524FF380E00C402F2 /* bbs.h in Headers */ = {isa = PBXBuildFile; fileRef = 9387DA0424FF380E00C402F2 /* bbs.h */; };
+		9387DA0824FF382800C402F2 /* libbbs.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9387DA0724FF382800C402F2 /* libbbs.a */; };
+		9387DA0B24FF9EEE00C402F2 /* bbs_signature.m in Sources */ = {isa = PBXBuildFile; fileRef = 9387DA0A24FF9EEE00C402F2 /* bbs_signature.m */; };
+		9387DA0D250047EB00C402F2 /* bbs_key_pair.m in Sources */ = {isa = PBXBuildFile; fileRef = 9387DA0C250047EB00C402F2 /* bbs_key_pair.m */; };
+		9387DA102500715700C402F2 /* bbs_signature.m in Sources */ = {isa = PBXBuildFile; fileRef = 9387DA0F2500715700C402F2 /* bbs_signature.m */; };
+		9387DA132501C3C900C402F2 /* bbs_signature_proof.m in Sources */ = {isa = PBXBuildFile; fileRef = 9387DA122501C3C900C402F2 /* bbs_signature_proof.m */; };
+		9387DA152501D4CF00C402F2 /* bbs_signature_proof.m in Sources */ = {isa = PBXBuildFile; fileRef = 9387DA142501D4CF00C402F2 /* bbs_signature_proof.m */; };
+		9387DA18250596C100C402F2 /* BbsSignatureError.m in Sources */ = {isa = PBXBuildFile; fileRef = 9387DA17250596C100C402F2 /* BbsSignatureError.m */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		9309BC4724FDFE45004B1B6E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 9309BC2824FDF470004B1B6E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9309BC2F24FDF470004B1B6E;
+			remoteInfo = "bbs-signatures";
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		9309BC2E24FDF470004B1B6E /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+				9309BC3624FDF470004B1B6E /* bls12381g2_key_pair.h in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		9309BC3024FDF470004B1B6E /* libbbs-signatures.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libbbs-signatures.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		9309BC3324FDF470004B1B6E /* bls12381g2_key_pair.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = bls12381g2_key_pair.h; sourceTree = "<group>"; };
+		9309BC3424FDF470004B1B6E /* bls12381g2_key_pair.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = bls12381g2_key_pair.m; sourceTree = "<group>"; };
+		9309BC4124FDFE45004B1B6E /* Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		9309BC4324FDFE45004B1B6E /* bls12381g2_key_pair.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = bls12381g2_key_pair.m; sourceTree = "<group>"; };
+		9309BC4524FDFE45004B1B6E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		935A71AC24FF054D0083FC6D /* bbs_key_pair.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = bbs_key_pair.h; sourceTree = "<group>"; };
+		935A71AD24FF05F10083FC6D /* bbs_key_pair.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = bbs_key_pair.m; sourceTree = "<group>"; };
+		9387DA0424FF380E00C402F2 /* bbs.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = bbs.h; path = libraries/bbs.h; sourceTree = "<group>"; };
+		9387DA0724FF382800C402F2 /* libbbs.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libbbs.a; path = libraries/libbbs.a; sourceTree = "<group>"; };
+		9387DA0924FF9ED300C402F2 /* bbs_signature.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = bbs_signature.h; sourceTree = "<group>"; };
+		9387DA0A24FF9EEE00C402F2 /* bbs_signature.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = bbs_signature.m; sourceTree = "<group>"; };
+		9387DA0C250047EB00C402F2 /* bbs_key_pair.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = bbs_key_pair.m; sourceTree = "<group>"; };
+		9387DA0E2500497F00C402F2 /* bbs_signatures.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = bbs_signatures.h; sourceTree = "<group>"; };
+		9387DA0F2500715700C402F2 /* bbs_signature.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = bbs_signature.m; path = tests/bbs_signature.m; sourceTree = SOURCE_ROOT; };
+		9387DA112501C25000C402F2 /* bbs_signature_proof.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = bbs_signature_proof.h; sourceTree = "<group>"; };
+		9387DA122501C3C900C402F2 /* bbs_signature_proof.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = bbs_signature_proof.m; sourceTree = "<group>"; };
+		9387DA142501D4CF00C402F2 /* bbs_signature_proof.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = bbs_signature_proof.m; path = tests/bbs_signature_proof.m; sourceTree = SOURCE_ROOT; };
+		9387DA1625058FF400C402F2 /* BbsSignatureError.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BbsSignatureError.h; sourceTree = "<group>"; };
+		9387DA17250596C100C402F2 /* BbsSignatureError.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BbsSignatureError.m; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		9309BC2D24FDF470004B1B6E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9387DA0824FF382800C402F2 /* libbbs.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9309BC3E24FDFE45004B1B6E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9309BC4624FDFE45004B1B6E /* libbbs-signatures.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		9309BC2724FDF470004B1B6E = {
+			isa = PBXGroup;
+			children = (
+				9387DA0424FF380E00C402F2 /* bbs.h */,
+				9309BC3224FDF470004B1B6E /* bbs-signatures */,
+				9309BC4224FDFE45004B1B6E /* Tests */,
+				9309BC3124FDF470004B1B6E /* Products */,
+				9387DA0624FF382700C402F2 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		9309BC3124FDF470004B1B6E /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				9309BC3024FDF470004B1B6E /* libbbs-signatures.a */,
+				9309BC4124FDFE45004B1B6E /* Tests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		9309BC3224FDF470004B1B6E /* bbs-signatures */ = {
+			isa = PBXGroup;
+			children = (
+				9309BC3324FDF470004B1B6E /* bls12381g2_key_pair.h */,
+				9309BC3424FDF470004B1B6E /* bls12381g2_key_pair.m */,
+				935A71AC24FF054D0083FC6D /* bbs_key_pair.h */,
+				935A71AD24FF05F10083FC6D /* bbs_key_pair.m */,
+				9387DA0924FF9ED300C402F2 /* bbs_signature.h */,
+				9387DA0A24FF9EEE00C402F2 /* bbs_signature.m */,
+				9387DA0E2500497F00C402F2 /* bbs_signatures.h */,
+				9387DA112501C25000C402F2 /* bbs_signature_proof.h */,
+				9387DA122501C3C900C402F2 /* bbs_signature_proof.m */,
+				9387DA1625058FF400C402F2 /* BbsSignatureError.h */,
+				9387DA17250596C100C402F2 /* BbsSignatureError.m */,
+			);
+			path = "bbs-signatures";
+			sourceTree = "<group>";
+		};
+		9309BC4224FDFE45004B1B6E /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				9309BC4324FDFE45004B1B6E /* bls12381g2_key_pair.m */,
+				9309BC4524FDFE45004B1B6E /* Info.plist */,
+				9387DA0C250047EB00C402F2 /* bbs_key_pair.m */,
+				9387DA0F2500715700C402F2 /* bbs_signature.m */,
+				9387DA142501D4CF00C402F2 /* bbs_signature_proof.m */,
+			);
+			path = Tests;
+			sourceTree = "<group>";
+		};
+		9387DA0624FF382700C402F2 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				9387DA0724FF382800C402F2 /* libbbs.a */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		9309BC4E24FE0936004B1B6E /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9387DA0524FF380E00C402F2 /* bbs.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		9309BC2F24FDF470004B1B6E /* bbs-signatures */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9309BC3924FDF470004B1B6E /* Build configuration list for PBXNativeTarget "bbs-signatures" */;
+			buildPhases = (
+				9309BC4E24FE0936004B1B6E /* Headers */,
+				9309BC2C24FDF470004B1B6E /* Sources */,
+				9309BC2D24FDF470004B1B6E /* Frameworks */,
+				9309BC2E24FDF470004B1B6E /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "bbs-signatures";
+			productName = "bbs-signatures";
+			productReference = 9309BC3024FDF470004B1B6E /* libbbs-signatures.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		9309BC4024FDFE45004B1B6E /* Tests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9309BC4924FDFE45004B1B6E /* Build configuration list for PBXNativeTarget "Tests" */;
+			buildPhases = (
+				9309BC3D24FDFE45004B1B6E /* Sources */,
+				9309BC3E24FDFE45004B1B6E /* Frameworks */,
+				9309BC3F24FDFE45004B1B6E /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				9309BC4824FDFE45004B1B6E /* PBXTargetDependency */,
+			);
+			name = Tests;
+			productName = Tests;
+			productReference = 9309BC4124FDFE45004B1B6E /* Tests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		9309BC2824FDF470004B1B6E /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1120;
+				ORGANIZATIONNAME = "Tobias Looker";
+				TargetAttributes = {
+					9309BC2F24FDF470004B1B6E = {
+						CreatedOnToolsVersion = 11.2;
+						LastSwiftMigration = 1120;
+					};
+					9309BC4024FDFE45004B1B6E = {
+						CreatedOnToolsVersion = 11.2;
+					};
+				};
+			};
+			buildConfigurationList = 9309BC2B24FDF470004B1B6E /* Build configuration list for PBXProject "bbs-signatures" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 9309BC2724FDF470004B1B6E;
+			productRefGroup = 9309BC3124FDF470004B1B6E /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				9309BC2F24FDF470004B1B6E /* bbs-signatures */,
+				9309BC4024FDFE45004B1B6E /* Tests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		9309BC3F24FDFE45004B1B6E /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		9309BC2C24FDF470004B1B6E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9387DA0B24FF9EEE00C402F2 /* bbs_signature.m in Sources */,
+				9387DA18250596C100C402F2 /* BbsSignatureError.m in Sources */,
+				9387DA132501C3C900C402F2 /* bbs_signature_proof.m in Sources */,
+				9309BC3524FDF470004B1B6E /* bls12381g2_key_pair.m in Sources */,
+				935A71AE24FF05F10083FC6D /* bbs_key_pair.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9309BC3D24FDFE45004B1B6E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9387DA102500715700C402F2 /* bbs_signature.m in Sources */,
+				9387DA152501D4CF00C402F2 /* bbs_signature_proof.m in Sources */,
+				9309BC4424FDFE45004B1B6E /* bls12381g2_key_pair.m in Sources */,
+				9387DA0D250047EB00C402F2 /* bbs_key_pair.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		9309BC4824FDFE45004B1B6E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 9309BC2F24FDF470004B1B6E /* bbs-signatures */;
+			targetProxy = 9309BC4724FDFE45004B1B6E /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		9309BC3724FDF470004B1B6E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				"HEADER_SEARCH_PATHS[arch=*]" = (
+					libraries,
+					"bbs-signatures",
+				);
+				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				VALID_ARCHS = "arm64 arm64e";
+			};
+			name = Debug;
+		};
+		9309BC3824FDF470004B1B6E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				"HEADER_SEARCH_PATHS[arch=*]" = libraries;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+				VALID_ARCHS = "arm64 arm64e";
+			};
+			name = Release;
+		};
+		9309BC3A24FDF470004B1B6E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/bbs-signatures",
+					"$(PROJECT_DIR)/libraries",
+				);
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "bbs-signatures/bbs-signatures-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		9309BC3B24FDF470004B1B6E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/bbs-signatures",
+					"$(PROJECT_DIR)/libraries",
+				);
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "bbs-signatures/bbs-signatures-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		9309BC4A24FDFE45004B1B6E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = Tests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = mattr.Tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		9309BC4B24FDFE45004B1B6E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = Tests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = mattr.Tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		9309BC2B24FDF470004B1B6E /* Build configuration list for PBXProject "bbs-signatures" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9309BC3724FDF470004B1B6E /* Debug */,
+				9309BC3824FDF470004B1B6E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		9309BC3924FDF470004B1B6E /* Build configuration list for PBXNativeTarget "bbs-signatures" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9309BC3A24FDF470004B1B6E /* Debug */,
+				9309BC3B24FDF470004B1B6E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		9309BC4924FDFE45004B1B6E /* Build configuration list for PBXNativeTarget "Tests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9309BC4A24FDFE45004B1B6E /* Debug */,
+				9309BC4B24FDFE45004B1B6E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 9309BC2824FDF470004B1B6E /* Project object */;
+}

--- a/wrappers/obj-c/bbs-signatures.xcodeproj/xcshareddata/xcschemes/bbs-signatures.xcscheme
+++ b/wrappers/obj-c/bbs-signatures.xcodeproj/xcshareddata/xcschemes/bbs-signatures.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1120"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "9309BC2F24FDF470004B1B6E"
+               BuildableName = "libbbs-signatures.a"
+               BlueprintName = "bbs-signatures"
+               ReferencedContainer = "container:bbs-signatures.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "9309BC4024FDFE45004B1B6E"
+               BuildableName = "Tests.xctest"
+               BlueprintName = "Tests"
+               ReferencedContainer = "container:bbs-signatures.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "9309BC2F24FDF470004B1B6E"
+            BuildableName = "libbbs-signatures.a"
+            BlueprintName = "bbs-signatures"
+            ReferencedContainer = "container:bbs-signatures.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/wrappers/obj-c/bbs-signatures/BbsSignatureError.h
+++ b/wrappers/obj-c/bbs-signatures/BbsSignatureError.h
@@ -1,0 +1,14 @@
+#ifndef NSError_BbsSignatureError_h
+#define NSError_BbsSignatureError_h
+
+#import <Foundation/Foundation.h>
+#include "bbs.h"
+
+@interface BbsSignatureError: NSObject
+
+//TODO review ideally this would be an extension of NSError but there were issues with this approach
++ (NSError*) errorFromBbsSignatureError:(bbs_signature_error_t *) error;
+
+@end
+
+#endif /* NSError_BbsSignatureError_h */

--- a/wrappers/obj-c/bbs-signatures/BbsSignatureError.m
+++ b/wrappers/obj-c/bbs-signatures/BbsSignatureError.m
@@ -1,0 +1,22 @@
+#import <Foundation/Foundation.h>
+#import "BbsSignatureError.h"
+#import "bbs.h"
+
+static NSString *const BbsSignatureErrorDomain = @"BbsSignatureError";
+
+@implementation BbsSignatureError
+
++ (NSError *)errorFromBbsSignatureError:(bbs_signature_error_t *)error {
+    
+    NSMutableDictionary *userInfo = [NSMutableDictionary new];
+    
+    if (error->message != NULL) {
+        [userInfo setValue:[NSString stringWithUTF8String:error->message] forKey:@"message"];
+        free(error->message);
+    }
+    
+    free(error);
+    return [NSError errorWithDomain:BbsSignatureErrorDomain code:error->code userInfo:userInfo];
+}
+
+@end

--- a/wrappers/obj-c/bbs-signatures/bbs.h
+++ b/wrappers/obj-c/bbs-signatures/bbs.h
@@ -1,0 +1,311 @@
+#ifndef bbs_h
+#define bbs_h
+
+#include <stdint.h>
+
+/* Used for receiving a bbs_signature_byte_buffer_t from C that was allocated by either C or Rust.
+*  If Rust allocated, then the outgoing struct is `ffi_support::bbs_signature_byte_buffer_t`
+*  Caller is responsible for calling free where applicable.
+*/
+typedef struct {
+    int64_t len;
+    uint8_t *_Nonnull data;
+} bbs_signature_byte_buffer_t;
+
+typedef struct {
+    int32_t code;
+    char *_Nullable message; /* note: nullable */
+} bbs_signature_error_t;
+
+typedef enum {
+    Revealed = 1,
+    HiddenProofSpecificBlinding = 2,
+    HiddenExternalBlinding = 3,
+} bbs_signature_proof_message_t;
+
+typedef enum {
+    /* The proof verified */
+    Success = 200,
+    /* The proof failed because the signature proof of knowledge failed */
+    BadSignature = 400,
+    /* The proof failed because a hidden message was invalid when the proof was created */
+    BadHiddenMessage = 401,
+    /* The proof failed because a revealed message was invalid */
+    BadRevealedMessage = 402,
+} bbs_signature_proof_status;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void bbs_string_free(char *_Nullable string);
+void bbs_byte_buffer_free(bbs_signature_byte_buffer_t data);
+
+uint64_t bbs_blind_commitment_context_init(bbs_signature_error_t *_Nullable err);
+
+int32_t bbs_blind_commitment_context_finish(uint64_t handle,
+                                            bbs_signature_byte_buffer_t *_Nullable commitment,
+                                            bbs_signature_byte_buffer_t *_Nullable out_context,
+                                            bbs_signature_byte_buffer_t *_Nullable blinding_factor,
+                                            bbs_signature_error_t *_Nullable err);
+
+int32_t bbs_blind_commitment_context_add_message_string(uint64_t handle,
+                                                        uint32_t index,
+                                                        const char *_Nullable const message,
+                                                        bbs_signature_error_t *_Nullable err);
+
+int32_t bbs_blind_commitment_context_add_message_bytes(uint64_t handle,
+                                                       uint32_t index,
+                                                       bbs_signature_byte_buffer_t message,
+                                                       bbs_signature_error_t *_Nullable err);
+
+int32_t bbs_blind_commitment_context_add_message_prehashed(uint64_t handle,
+                                                           uint32_t index,
+                                                           bbs_signature_byte_buffer_t message,
+                                                           bbs_signature_error_t *_Nullable err);
+
+int32_t bbs_blind_commitment_context_set_public_key(uint64_t handle,
+                                                    bbs_signature_byte_buffer_t public_key,
+                                                    bbs_signature_error_t *_Nullable err);
+
+int32_t bbs_blind_commitment_context_set_nonce_string(uint64_t handle,
+                                                      const char *_Nullable const message,
+                                                      bbs_signature_error_t *_Nullable err);
+
+int32_t bbs_blind_commitment_context_set_nonce_bytes(uint64_t handle,
+                                                     bbs_signature_byte_buffer_t message,
+                                                     bbs_signature_error_t *_Nullable err);
+
+int32_t bbs_blind_commitment_context_set_nonce_prehashed(uint64_t handle,
+                                                         bbs_signature_byte_buffer_t message,
+                                                         bbs_signature_error_t *_Nullable err);
+
+int32_t bbs_blind_sign_context_finish(uint64_t handle,
+                                      bbs_signature_byte_buffer_t *_Nullable blinded_signature,
+                                      bbs_signature_error_t *_Nullable err);
+
+int32_t bbs_blind_sign_context_add_message_string(uint64_t handle,
+                                                  uint32_t index,
+                                                  const char *_Nullable const message,
+                                                  bbs_signature_error_t *_Nullable err);
+
+int32_t bbs_blind_sign_context_add_message_bytes(uint64_t handle,
+                                                 uint32_t index,
+                                                 bbs_signature_byte_buffer_t message,
+                                                 bbs_signature_error_t *_Nullable err);
+
+int32_t bbs_blind_sign_context_add_message_prehashed(uint64_t handle,
+                                                     uint32_t index,
+                                                     bbs_signature_byte_buffer_t message,
+                                                     bbs_signature_error_t *_Nullable err);
+
+int32_t bbs_blind_sign_context_set_secret_key(uint64_t handle,
+                                              bbs_signature_byte_buffer_t secret_key,
+                                              bbs_signature_error_t *_Nullable err);
+
+int32_t bbs_blind_sign_context_set_public_key(uint64_t handle,
+                                              bbs_signature_byte_buffer_t public_key,
+                                              bbs_signature_error_t *_Nullable err);
+
+int32_t bbs_blind_sign_context_set_commitment(uint64_t handle,
+                                              bbs_signature_byte_buffer_t public_key ,
+                                              bbs_signature_error_t *_Nullable err);
+
+uint64_t bbs_blind_sign_context_init(bbs_signature_error_t *_Nullable err);
+
+int32_t bbs_blind_signature_size(void);
+
+int32_t bbs_unblind_signature(bbs_signature_byte_buffer_t blind_signature,
+                              bbs_signature_byte_buffer_t blinding_factor,
+                              bbs_signature_byte_buffer_t *_Nullable unblind_signature,
+                              bbs_signature_error_t *_Nullable err);
+
+int32_t bbs_create_proof_context_finish(uint64_t handle, bbs_signature_byte_buffer_t *_Nullable proof, bbs_signature_error_t *_Nullable err);
+
+int32_t bbs_create_proof_context_set_public_key(uint64_t handle,
+                                                bbs_signature_byte_buffer_t public_key,
+                                                bbs_signature_error_t *_Nullable err);
+
+int32_t bbs_create_proof_context_set_signature(uint64_t handle,
+                                               bbs_signature_byte_buffer_t signature ,
+                                               bbs_signature_error_t *_Nullable err);
+
+int32_t bbs_create_proof_context_set_nonce_string(uint64_t handle,
+                                                  const char *_Nullable const message ,
+                                                  bbs_signature_error_t *_Nullable err);
+
+int32_t bbs_create_proof_context_set_nonce_bytes(uint64_t handle,
+                                                 bbs_signature_byte_buffer_t message,
+                                                 bbs_signature_error_t *_Nullable err);
+
+int32_t bbs_create_proof_context_set_nonce_prehashed(uint64_t handle,
+                                                     bbs_signature_byte_buffer_t message,
+                                                     bbs_signature_error_t *_Nullable err);
+
+int32_t bbs_create_proof_context_add_proof_message_string(uint64_t handle,
+                                                          const char *_Nullable const message,
+                                                          bbs_signature_proof_message_t xtype,
+                                                          bbs_signature_byte_buffer_t blinding_factor,
+                                                          bbs_signature_error_t *_Nullable err);
+
+int32_t bbs_create_proof_context_add_proof_message_bytes(uint64_t handle,
+                                                         bbs_signature_byte_buffer_t message,
+                                                         bbs_signature_proof_message_t xtype,
+                                                         bbs_signature_byte_buffer_t blinding_factor,
+                                                         bbs_signature_error_t *_Nullable err);
+
+int32_t bbs_create_proof_context_add_proof_message_prehashed(uint64_t handle,
+                                                             bbs_signature_byte_buffer_t message,
+                                                             bbs_signature_proof_message_t xtype,
+                                                             bbs_signature_byte_buffer_t blinding_factor,
+                                                             bbs_signature_error_t *_Nullable err);
+
+uint64_t bbs_create_proof_context_init(bbs_signature_error_t *_Nullable err);
+
+int32_t bbs_sign_context_add_message_string(uint64_t handle,
+                                            const char *_Nullable const message,
+                                            bbs_signature_error_t *_Nullable err);
+
+int32_t bbs_sign_context_add_message_bytes(uint64_t handle,
+                                           bbs_signature_byte_buffer_t message,
+                                           bbs_signature_error_t *_Nullable err);
+
+int32_t bbs_sign_context_add_message_prehashed(uint64_t handle,
+                                               bbs_signature_byte_buffer_t message,
+                                               bbs_signature_error_t *_Nullable err);
+
+int32_t bbs_sign_context_set_secret_key(uint64_t handle,
+                                        bbs_signature_byte_buffer_t secret_key,
+                                        bbs_signature_error_t *_Nullable err);
+
+int32_t bbs_sign_context_set_public_key(uint64_t handle,
+                                        bbs_signature_byte_buffer_t public_key,
+                                        bbs_signature_error_t *_Nullable err);
+
+int32_t bbs_sign_context_finish(uint64_t handle, bbs_signature_byte_buffer_t *_Nullable signature, bbs_signature_error_t *_Nullable err);
+
+uint64_t bbs_sign_context_init(bbs_signature_error_t *_Nullable err);
+
+int32_t bbs_signature_size(void);
+
+int32_t bbs_verify_context_add_message_bytes(uint64_t handle,
+                                             bbs_signature_byte_buffer_t message,
+                                             bbs_signature_error_t *_Nullable err);
+
+int32_t bbs_verify_context_add_message_prehashed(uint64_t handle,
+                                                 bbs_signature_byte_buffer_t message,
+                                                 bbs_signature_error_t *_Nullable err);
+
+int32_t bbs_verify_context_add_message_string(uint64_t handle,
+                                              const char *_Nullable const message,
+                                              bbs_signature_error_t *_Nullable err);
+
+int32_t bbs_verify_context_set_public_key(uint64_t handle,
+                                          bbs_signature_byte_buffer_t public_key,
+                                          bbs_signature_error_t *_Nullable err);
+int32_t bbs_verify_context_set_signature(uint64_t handle,
+                                         bbs_signature_byte_buffer_t signature,
+                                         bbs_signature_error_t *_Nullable err);
+
+int32_t bbs_verify_context_finish(uint64_t handle, bbs_signature_error_t *_Nullable err);
+
+uint64_t bbs_verify_context_init(bbs_signature_error_t *_Nullable err);
+
+int32_t bbs_verify_blind_commitment_context_add_blinded(uint64_t handle,
+                                                        uint32_t index,
+                                                        bbs_signature_error_t *_Nullable err);
+
+int32_t bbs_verify_blind_commitment_context_set_public_key(uint64_t handle,
+                                                           bbs_signature_byte_buffer_t public_key,
+                                                           bbs_signature_error_t *_Nullable err);
+
+int32_t bbs_verify_blind_commitment_context_set_nonce_string(uint64_t handle,
+                                                             const char *_Nullable const message,
+                                                             bbs_signature_error_t *_Nullable err);
+
+int32_t bbs_verify_blind_commitment_context_set_nonce_bytes(uint64_t handle,
+                                                            bbs_signature_byte_buffer_t message,
+                                                            bbs_signature_error_t *_Nullable err);
+
+int32_t bbs_verify_blind_commitment_context_set_nonce_prehashed(uint64_t handle,
+                                                                bbs_signature_byte_buffer_t message,
+                                                                bbs_signature_error_t *_Nullable err);
+
+int32_t bbs_verify_blind_commitment_context_set_proof(uint64_t handle,
+                                                      bbs_signature_byte_buffer_t proof,
+                                                      bbs_signature_error_t *_Nullable err);
+
+uint64_t bbs_verify_blind_commitment_context_init(bbs_signature_error_t *_Nullable err);
+
+int32_t bbs_verify_blind_commitment_context_finish(uint64_t handle, bbs_signature_error_t *_Nullable err);
+
+int32_t bbs_verify_proof_context_add_revealed_index(uint64_t handle,
+                                                    uint32_t index,
+                                                    bbs_signature_error_t *_Nullable err);
+
+int32_t bbs_verify_proof_context_finish(uint64_t handle, bbs_signature_error_t *_Nullable err);
+
+
+int32_t bbs_verify_proof_context_set_proof(uint64_t handle,
+                                           bbs_signature_byte_buffer_t proof,
+                                           bbs_signature_error_t *_Nullable err);
+
+int32_t bbs_verify_proof_context_set_public_key(uint64_t handle,
+                                                bbs_signature_byte_buffer_t public_key,
+                                                bbs_signature_error_t *_Nullable err);
+
+
+int32_t bbs_verify_proof_context_set_nonce_string(uint64_t handle,
+                                                  const char *_Nullable const message,
+                                                  bbs_signature_error_t *_Nullable err);
+
+int32_t bbs_verify_proof_context_set_nonce_bytes(uint64_t handle,
+                                                 bbs_signature_byte_buffer_t message,
+                                                 bbs_signature_error_t *_Nullable err);
+
+int32_t bbs_verify_proof_context_set_nonce_prehashed(uint64_t handle,
+                                                     bbs_signature_byte_buffer_t message,
+                                                     bbs_signature_error_t *_Nullable err);
+
+
+int32_t bbs_verify_proof_context_add_message_string(uint64_t handle,
+                                                    const char *_Nullable const message,
+                                                    bbs_signature_error_t *_Nullable err);
+
+int32_t bbs_verify_proof_context_add_message_bytes(uint64_t handle,
+                                                   bbs_signature_byte_buffer_t message,
+                                                   bbs_signature_error_t *_Nullable err);
+
+int32_t bbs_verify_proof_context_add_message_prehashed(uint64_t handle,
+                                                       bbs_signature_byte_buffer_t message,
+                                                       bbs_signature_error_t *_Nullable err);
+
+uint64_t bbs_verify_proof_context_init(bbs_signature_error_t *_Nullable err);
+
+int32_t bls_generate_key(bbs_signature_byte_buffer_t seed,
+                         bbs_signature_byte_buffer_t *_Nullable public_key,
+                         bbs_signature_byte_buffer_t *_Nullable secret_key,
+                         bbs_signature_error_t *_Nullable err);
+
+int32_t bls_get_public_key(bbs_signature_byte_buffer_t secret_key ,
+                           bbs_signature_byte_buffer_t *_Nullable public_key,
+                           bbs_signature_error_t *_Nullable err);
+
+int32_t bls_public_key_size(void);
+
+int32_t bls_public_key_to_bbs_key(bbs_signature_byte_buffer_t d_public_key,
+                                  uint32_t message_count,
+                                  bbs_signature_byte_buffer_t *_Nullable public_key,
+                                  bbs_signature_error_t *_Nullable err);
+
+int32_t bls_secret_key_size(void);
+
+int32_t bls_secret_key_to_bbs_key(bbs_signature_byte_buffer_t secret_key,
+                                  uint32_t message_count,
+                                  bbs_signature_byte_buffer_t *_Nullable public_key,
+                                  bbs_signature_error_t *_Nullable err);
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif /* bbs_h */

--- a/wrappers/obj-c/bbs-signatures/bbs_key_pair.h
+++ b/wrappers/obj-c/bbs-signatures/bbs_key_pair.h
@@ -19,17 +19,17 @@
 /**
 * @brief Creates a BBS key pair from data
 */
-- (nullable instancetype)initFromPublicKey:(NSData* _Nonnull)data : (size_t)messageCount;
+- (nullable instancetype)initWithData:(NSData* _Nonnull)publicKey : (size_t)messageCount;
+
+/**
+* @brief Creates a BBS key pair from data
+*/
+- (nullable instancetype)initWithData:(NSData* _Nonnull)publicKey : (size_t)messageCount andSecretKey:(NSData* _Nullable)secretKey;
 
 /**
 * @brief Initializes a BBS+ key pair from a BLS 12-381 G2 key pair
 */
-- (nullable instancetype)initFromBls12381G2KeyPair:(Bls12381G2KeyPair* _Nonnull)keyPair : (size_t)messageCount withError:(NSError *_Nullable*_Nullable)errorPtr;
-
-/**
-* @brief Initializes a BBS+ public key from a BLS 12-381 G2 public key
-*/
-- (nullable instancetype)initFromBls12381G2PublicKey:(NSData* _Nonnull)publicKey : (size_t)messageCount withError:(NSError *_Nullable*_Nullable)errorPtr;
+- (nullable instancetype)initWithBls12381G2KeyPair:(Bls12381G2KeyPair* _Nonnull)keyPair : (size_t)messageCount withError:(NSError *_Nullable*_Nullable)errorPtr;
 
 @end
 

--- a/wrappers/obj-c/bbs-signatures/bbs_key_pair.h
+++ b/wrappers/obj-c/bbs-signatures/bbs_key_pair.h
@@ -4,11 +4,11 @@
 #import "bbs.h"
 #import "bls12381g2_key_pair.h"
 
-/** @brief BBS+ key pair */
+/** @brief BBS key pair */
 @interface BbsKeyPair : NSObject
 
 /** @brief secret key */
-@property(nonatomic, readonly) NSData *_Nonnull secretKey;
+@property(nonatomic, readonly) NSData *_Nullable secretKey;
 
 /** @brief public key */
 @property(nonatomic, readonly) NSData *_Nonnull publicKey;
@@ -17,19 +17,24 @@
 @property(nonatomic, readonly) size_t messageCount;
 
 /**
-* @brief Creates a BBS key pair from data
+* @brief Initialises a BBS public key from the raw bytes of the public key
 */
-- (nullable instancetype)initWithData:(NSData* _Nonnull)publicKey : (size_t)messageCount;
+- (nullable instancetype)initWithData:(NSData* _Nonnull)publicKey
+                        messageCount:(size_t)messageCount;
 
 /**
-* @brief Creates a BBS key pair from data
+* @brief Initialises a BBS public key from the raw bytes of the public and secret key
 */
-- (nullable instancetype)initWithData:(NSData* _Nonnull)publicKey : (size_t)messageCount andSecretKey:(NSData* _Nullable)secretKey;
+- (nullable instancetype)initWithData:(NSData* _Nonnull)publicKey
+                         messageCount:(size_t)messageCount
+                         andSecretKey:(NSData* _Nullable)secretKey;
 
 /**
-* @brief Initializes a BBS+ key pair from a BLS 12-381 G2 key pair
+* @brief Initialises a BBS public key from a BLS 12-381 G2 key pair
 */
-- (nullable instancetype)initWithBls12381G2KeyPair:(Bls12381G2KeyPair* _Nonnull)keyPair : (size_t)messageCount withError:(NSError *_Nullable*_Nullable)errorPtr;
+- (nullable instancetype)initWithBls12381G2KeyPair:(Bls12381G2KeyPair* _Nonnull)keyPair
+                                  messageCount:(size_t)messageCount
+                                         withError:(NSError *_Nullable*_Nullable)errorPtr;
 
 @end
 

--- a/wrappers/obj-c/bbs-signatures/bbs_key_pair.h
+++ b/wrappers/obj-c/bbs-signatures/bbs_key_pair.h
@@ -1,0 +1,36 @@
+#ifndef bbs_key_pair_h
+#define bbs_key_pair_h
+
+#import "bbs.h"
+#import "bls12381g2_key_pair.h"
+
+/** @brief BBS+ key pair */
+@interface BbsKeyPair : NSObject
+
+/** @brief secret key */
+@property(nonatomic, readonly) NSData *_Nonnull secretKey;
+
+/** @brief public key */
+@property(nonatomic, readonly) NSData *_Nonnull publicKey;
+
+/** @brief message count */
+@property(nonatomic, readonly) size_t messageCount;
+
+/**
+* @brief Creates a BBS key pair from data
+*/
+- (nullable instancetype)initFromPublicKey:(NSData* _Nonnull)data : (size_t)messageCount;
+
+/**
+* @brief Initializes a BBS+ key pair from a BLS 12-381 G2 key pair
+*/
+- (nullable instancetype)initFromBls12381G2KeyPair:(Bls12381G2KeyPair* _Nonnull)keyPair : (size_t)messageCount withError:(NSError *_Nullable*_Nullable)errorPtr;
+
+/**
+* @brief Initializes a BBS+ public key from a BLS 12-381 G2 public key
+*/
+- (nullable instancetype)initFromBls12381G2PublicKey:(NSData* _Nonnull)publicKey : (size_t)messageCount withError:(NSError *_Nullable*_Nullable)errorPtr;
+
+@end
+
+#endif /* bbs_key_pair_h */

--- a/wrappers/obj-c/bbs-signatures/bbs_key_pair.m
+++ b/wrappers/obj-c/bbs-signatures/bbs_key_pair.m
@@ -1,0 +1,81 @@
+#import <Foundation/Foundation.h>
+
+#import "bbs_key_pair.h"
+#import "BbsSignatureError.h"
+
+/** @brief BBS+ key pair */
+@interface BbsKeyPair ()
+
+/** @brief secret key */
+@property(nonatomic, readwrite) NSData *secretKey;
+
+/** @brief public key */
+@property(nonatomic, readwrite) NSData *publicKey;
+
+/** @brief message count */
+@property(nonatomic, readwrite) size_t messageCount;
+
+@end
+
+/** @brief Implementation of A BBS+ Key pair */
+@implementation BbsKeyPair
+
+- (nullable instancetype)initFromPublicKey:(NSData* _Nonnull)data : (size_t)messageCount {
+    self.publicKey = data;
+    self.messageCount = messageCount;
+    return self;
+}
+
+/** @brief Initializes a BBS+ key pair from a BLS 12-381 G2 key pair*/
+- (nullable instancetype)initFromBls12381G2KeyPair:(Bls12381G2KeyPair* _Nonnull)keyPair : (size_t)messageCount withError:(NSError *_Nullable*_Nullable)errorPtr {
+    [self bls12381G2ToBbs: keyPair : messageCount withError:errorPtr];
+    return self;
+}
+
+/** @brief Initializes a BBS+ public key from a BLS 12-381 G2 public key*/
+- (nullable instancetype)initFromBls12381G2PublicKey:(NSData* _Nonnull)publicKey : (size_t)messageCount withError:(NSError *_Nullable*_Nullable)errorPtr {
+    [self bls12381G2PublicKeyToBbsPublicKey: publicKey : messageCount withError:errorPtr];
+    return self;
+}
+
+- (void) bls12381G2ToBbs:(Bls12381G2KeyPair* _Nonnull)keyPair : (size_t)messageCount withError:(NSError *_Nullable*_Nullable)errorPtr {
+    bbs_signature_byte_buffer_t publicKey;
+    publicKey.len = keyPair.publicKey.length;
+    publicKey.data = (uint8_t *)keyPair.publicKey.bytes;
+    
+    bbs_signature_byte_buffer_t *bbsPublicKey = (bbs_signature_byte_buffer_t*) malloc(sizeof(bbs_signature_byte_buffer_t));
+    bbs_signature_error_t *err = (bbs_signature_error_t*) malloc(sizeof(bbs_signature_error_t));
+    
+    if (bls_public_key_to_bbs_key(publicKey, (uint32_t)messageCount, bbsPublicKey, err) > 0) {
+        *errorPtr = [BbsSignatureError errorFromBbsSignatureError:err];
+        return;
+    }
+    
+    self.publicKey = [[NSData alloc] initWithBytesNoCopy:bbsPublicKey->data length:(NSUInteger)bbsPublicKey->len freeWhenDone:true];
+    self.secretKey = keyPair.secretKey;
+    self.messageCount = messageCount;
+    
+    free(err);
+}
+
+- (void) bls12381G2PublicKeyToBbsPublicKey:(NSData* _Nonnull)publicKeyData : (size_t)messageCount withError:(NSError *_Nullable*_Nullable)errorPtr {
+    
+    bbs_signature_byte_buffer_t publicKeyBuffer;
+    publicKeyBuffer.len = publicKeyData.length;
+    publicKeyBuffer.data = (uint8_t *)publicKeyData.bytes;
+    
+    bbs_signature_byte_buffer_t *publicKey = (bbs_signature_byte_buffer_t*) malloc(sizeof(bbs_signature_byte_buffer_t));
+    bbs_signature_error_t *err = (bbs_signature_error_t*) malloc(sizeof(bbs_signature_error_t));
+    
+    if (bls_public_key_to_bbs_key(publicKeyBuffer, (uint32_t)messageCount, publicKey, err) > 0) {
+        *errorPtr = [BbsSignatureError errorFromBbsSignatureError:err];
+        return;
+    }
+    
+    self.publicKey = [[NSData alloc] initWithBytesNoCopy:publicKey->data length:(NSUInteger)publicKey->len freeWhenDone:true];
+    self.messageCount = messageCount;
+    
+    free(err);
+}
+
+@end

--- a/wrappers/obj-c/bbs-signatures/bbs_key_pair.m
+++ b/wrappers/obj-c/bbs-signatures/bbs_key_pair.m
@@ -20,21 +20,22 @@
 /** @brief Implementation of A BBS+ Key pair */
 @implementation BbsKeyPair
 
-- (nullable instancetype)initFromPublicKey:(NSData* _Nonnull)data : (size_t)messageCount {
-    self.publicKey = data;
+- (nullable instancetype)initWithData:(NSData* _Nonnull)publicKey : (size_t)messageCount {
+    self.publicKey = publicKey;
+    self.messageCount = messageCount;
+    return self;
+}
+
+- (nullable instancetype)initWithData:(NSData* _Nonnull)publicKey : (size_t)messageCount andSecretKey:(NSData* _Nullable)secretKey {
+    self.publicKey = publicKey;
+    self.secretKey = secretKey;
     self.messageCount = messageCount;
     return self;
 }
 
 /** @brief Initializes a BBS+ key pair from a BLS 12-381 G2 key pair*/
-- (nullable instancetype)initFromBls12381G2KeyPair:(Bls12381G2KeyPair* _Nonnull)keyPair : (size_t)messageCount withError:(NSError *_Nullable*_Nullable)errorPtr {
+- (nullable instancetype)initWithBls12381G2KeyPair:(Bls12381G2KeyPair* _Nonnull)keyPair : (size_t)messageCount withError:(NSError *_Nullable*_Nullable)errorPtr {
     [self bls12381G2ToBbs: keyPair : messageCount withError:errorPtr];
-    return self;
-}
-
-/** @brief Initializes a BBS+ public key from a BLS 12-381 G2 public key*/
-- (nullable instancetype)initFromBls12381G2PublicKey:(NSData* _Nonnull)publicKey : (size_t)messageCount withError:(NSError *_Nullable*_Nullable)errorPtr {
-    [self bls12381G2PublicKeyToBbsPublicKey: publicKey : messageCount withError:errorPtr];
     return self;
 }
 

--- a/wrappers/obj-c/bbs-signatures/bbs_key_pair.m
+++ b/wrappers/obj-c/bbs-signatures/bbs_key_pair.m
@@ -3,7 +3,7 @@
 #import "bbs_key_pair.h"
 #import "BbsSignatureError.h"
 
-/** @brief BBS+ key pair */
+/** @brief BBS key pair */
 @interface BbsKeyPair ()
 
 /** @brief secret key */
@@ -17,29 +17,40 @@
 
 @end
 
-/** @brief Implementation of A BBS+ Key pair */
 @implementation BbsKeyPair
 
-- (nullable instancetype)initWithData:(NSData* _Nonnull)publicKey : (size_t)messageCount {
+- (nullable instancetype)initWithData:(NSData* _Nonnull)publicKey
+                         messageCount:(size_t)messageCount {
+    
     self.publicKey = publicKey;
     self.messageCount = messageCount;
     return self;
 }
 
-- (nullable instancetype)initWithData:(NSData* _Nonnull)publicKey : (size_t)messageCount andSecretKey:(NSData* _Nullable)secretKey {
+- (nullable instancetype)initWithData:(NSData* _Nonnull)publicKey
+                         messageCount:(size_t)messageCount
+                         andSecretKey:(NSData* _Nullable)secretKey {
+    
     self.publicKey = publicKey;
     self.secretKey = secretKey;
     self.messageCount = messageCount;
     return self;
 }
 
-/** @brief Initializes a BBS+ key pair from a BLS 12-381 G2 key pair*/
-- (nullable instancetype)initWithBls12381G2KeyPair:(Bls12381G2KeyPair* _Nonnull)keyPair : (size_t)messageCount withError:(NSError *_Nullable*_Nullable)errorPtr {
-    [self bls12381G2ToBbs: keyPair : messageCount withError:errorPtr];
+- (nullable instancetype)initWithBls12381G2KeyPair:(Bls12381G2KeyPair* _Nonnull)keyPair
+                                      messageCount:(size_t)messageCount
+                                         withError:(NSError *_Nullable*_Nullable)errorPtr {
+    
+    [self bls12381G2ToBbs:keyPair
+             messageCount:messageCount
+                withError:errorPtr];
     return self;
 }
 
-- (void) bls12381G2ToBbs:(Bls12381G2KeyPair* _Nonnull)keyPair : (size_t)messageCount withError:(NSError *_Nullable*_Nullable)errorPtr {
+- (void) bls12381G2ToBbs:(Bls12381G2KeyPair* _Nonnull)keyPair
+            messageCount:(size_t)messageCount
+               withError:(NSError *_Nullable*_Nullable)errorPtr {
+    
     bbs_signature_byte_buffer_t publicKey;
     publicKey.len = keyPair.publicKey.length;
     publicKey.data = (uint8_t *)keyPair.publicKey.bytes;
@@ -52,14 +63,19 @@
         return;
     }
     
-    self.publicKey = [[NSData alloc] initWithBytesNoCopy:bbsPublicKey->data length:(NSUInteger)bbsPublicKey->len freeWhenDone:true];
+    self.publicKey = [[NSData alloc] initWithBytesNoCopy:bbsPublicKey->data
+                                                  length:(NSUInteger)bbsPublicKey->len
+                                            freeWhenDone:true];
+    
     self.secretKey = keyPair.secretKey;
     self.messageCount = messageCount;
     
     free(err);
 }
 
-- (void) bls12381G2PublicKeyToBbsPublicKey:(NSData* _Nonnull)publicKeyData : (size_t)messageCount withError:(NSError *_Nullable*_Nullable)errorPtr {
+- (void) bls12381G2PublicKeyToBbsPublicKey:(NSData* _Nonnull)publicKeyData
+                              messageCount:(size_t)messageCount
+                                 withError:(NSError *_Nullable*_Nullable)errorPtr {
     
     bbs_signature_byte_buffer_t publicKeyBuffer;
     publicKeyBuffer.len = publicKeyData.length;

--- a/wrappers/obj-c/bbs-signatures/bbs_signature.h
+++ b/wrappers/obj-c/bbs-signatures/bbs_signature.h
@@ -3,6 +3,7 @@
 
 #include "bbs_key_pair.h"
 
+/** @brief BBS Signature */
 @interface BbsSignature : NSObject
 
 /** @brief signature */
@@ -11,27 +12,36 @@
 /**
 * @brief Creates a BBS signature from the raw bytes
 */
-- (nullable instancetype)initWithBytes:(NSData* _Nonnull)bytes withError:(NSError *_Nullable*_Nullable)errorPtr;
+- (nullable instancetype)initWithBytes:(NSData* _Nonnull)bytes
+                             withError:(NSError *_Nullable*_Nullable)errorPtr;
 
 /**
 * @brief Creates a BBS signature
 */
-- (nullable instancetype)sign:(BbsKeyPair* _Nonnull)keyPair : (NSArray* _Nonnull)messages withError:(NSError*_Nullable*_Nullable)errorPtr;
+- (nullable instancetype)sign:(BbsKeyPair* _Nonnull)keyPair
+                     messages:(NSArray* _Nonnull)messages
+                    withError:(NSError*_Nullable*_Nullable)errorPtr;
 
 /**
 * @brief Creates a BBS signature from a BLS12-381 G2 key pair
 */
-- (nullable instancetype)blsSign:(Bls12381G2KeyPair* _Nonnull)keyPair : (NSArray* _Nonnull)messages withError:(NSError *_Nullable*_Nullable)errorPtr;
+- (nullable instancetype)blsSign:(Bls12381G2KeyPair* _Nonnull)keyPair
+                        messages:(NSArray* _Nonnull)messages
+                       withError:(NSError *_Nullable*_Nullable)errorPtr;
 
 /**
 * @Verifies the BBS signature
 */
-- (bool)verify:(BbsKeyPair* _Nonnull)keyPair : (NSArray* _Nonnull)messages withError:(NSError *_Nullable*_Nullable)errorPtr;
+- (bool)verify:(BbsKeyPair* _Nonnull)keyPair
+      messages:(NSArray* _Nonnull)messages
+     withError:(NSError *_Nullable*_Nullable)errorPtr;
 
 /**
 * @Verifies the BBS signature from a BLS12-381 G2 key pair
 */
-- (bool)blsVerify:(Bls12381G2KeyPair* _Nonnull)keyPair : (NSArray* _Nonnull)messages withError:(NSError *_Nullable*_Nullable)errorPtr;
+- (bool)blsVerify:(Bls12381G2KeyPair* _Nonnull)keyPair
+         messages:(NSArray* _Nonnull)messages
+        withError:(NSError *_Nullable*_Nullable)errorPtr;
 
 @end
 

--- a/wrappers/obj-c/bbs-signatures/bbs_signature.h
+++ b/wrappers/obj-c/bbs-signatures/bbs_signature.h
@@ -1,0 +1,38 @@
+#ifndef bbs_signature_h
+#define bbs_signature_h
+
+#include "bbs_key_pair.h"
+
+@interface BbsSignature : NSObject
+
+/** @brief signature */
+@property(nonatomic, readonly) NSData *_Nonnull value;
+
+/**
+* @brief Creates a BBS signature from the raw bytes
+*/
+- (nullable instancetype)initWithBytes:(NSData* _Nonnull)bytes withError:(NSError *_Nullable*_Nullable)errorPtr;
+
+/**
+* @brief Creates a BBS signature
+*/
+- (nullable instancetype)sign:(BbsKeyPair* _Nonnull)keyPair : (NSArray* _Nonnull)messages withError:(NSError*_Nullable*_Nullable)errorPtr;
+
+/**
+* @brief Creates a BBS signature from a BLS12-381 G2 key pair
+*/
+- (nullable instancetype)blsSign:(Bls12381G2KeyPair* _Nonnull)keyPair : (NSArray* _Nonnull)messages withError:(NSError *_Nullable*_Nullable)errorPtr;
+
+/**
+* @Verifies the BBS signature
+*/
+- (bool)verify:(BbsKeyPair* _Nonnull)keyPair : (NSArray* _Nonnull)messages withError:(NSError *_Nullable*_Nullable)errorPtr;
+
+/**
+* @Verifies the BBS signature from a BLS12-381 G2 key pair
+*/
+- (bool)blsVerify:(Bls12381G2KeyPair* _Nonnull)keyPair : (NSArray* _Nonnull)messages withError:(NSError *_Nullable*_Nullable)errorPtr;
+
+@end
+
+#endif /* bbs_signature_h */

--- a/wrappers/obj-c/bbs-signatures/bbs_signature.m
+++ b/wrappers/obj-c/bbs-signatures/bbs_signature.m
@@ -3,6 +3,7 @@
 #import "bbs_signature.h"
 #import "BbsSignatureError.h"
 
+/** @brief BBS Signature */
 @interface BbsSignature ()
 
 /** @brief signature */
@@ -10,58 +11,101 @@
 
 @end
 
-/** @brief A BBS Signature */
+/** @brief BBS Signature */
 @implementation BbsSignature
 
-/** @brief Creates a BBS signature from the raw bytes  */
-- (nullable instancetype)initWithBytes:(NSData* _Nonnull)bytes withError:(NSError *_Nullable*_Nullable)errorPtr {
-    [self createFromBytes:bytes withError:errorPtr];
+/**
+* @brief Creates a BBS signature from the raw bytes
+*/
+- (nullable instancetype)initWithBytes:(NSData* _Nonnull)bytes
+                             withError:(NSError *_Nullable*_Nullable)errorPtr {
+    
+    [self createFromBytes:bytes
+                withError:errorPtr];
     return self;
 }
 
-/** @brief Initializes a key pair */
-- (nullable instancetype)sign:(BbsKeyPair* _Nonnull)keyPair : (NSArray* _Nonnull)messages withError:(NSError *_Nullable*_Nullable)errorPtr {
-    [self createSignature: keyPair : messages withError:errorPtr];
+/**
+* @brief Creates a BBS signature
+*/
+- (nullable instancetype)sign:(BbsKeyPair* _Nonnull)keyPair
+                     messages:(NSArray* _Nonnull)messages
+                    withError:(NSError *_Nullable*_Nullable)errorPtr {
+    
+    [self createSignature:keyPair
+                 messages:messages
+                withError:errorPtr];
     return self;
 }
 
-/** @brief Initializes a key pair */
-- (bool)verify:(BbsKeyPair* _Nonnull)keyPair : (NSArray* _Nonnull)messages withError:(NSError *_Nullable*_Nullable)errorPtr {
-    return [self verifySignature:keyPair: messages withError:errorPtr];
+/**
+* @Verifies the BBS signature
+*/
+- (bool)verify:(BbsKeyPair* _Nonnull)keyPair
+      messages:(NSArray* _Nonnull)messages
+     withError:(NSError *_Nullable*_Nullable)errorPtr {
+    
+    return [self verifySignature:keyPair
+                        messages:messages
+                       withError:errorPtr];
 }
 
-/** @brief Initializes a key pair */
-- (nullable instancetype)blsSign:(Bls12381G2KeyPair* _Nonnull)keyPair : (NSArray* _Nonnull)messages withError:(NSError *_Nullable*_Nullable)errorPtr {
-    [self createSignatureFromBls12381G2: keyPair : messages withError:errorPtr];
+/**
+* @brief Creates a BBS signature from a BLS12-381 G2 key pair
+*/
+- (nullable instancetype)blsSign:(Bls12381G2KeyPair* _Nonnull)keyPair
+                        messages:(NSArray* _Nonnull)messages
+                       withError:(NSError *_Nullable*_Nullable)errorPtr {
+    
+    [self createSignatureFromBls12381G2:keyPair
+                               messages:messages
+                              withError:errorPtr];
     return self;
 }
 
-/** @brief Initializes a key pair */
-- (bool)blsVerify:(Bls12381G2KeyPair* _Nonnull)keyPair : (NSArray* _Nonnull)messages withError:(NSError *_Nullable*_Nullable)errorPtr {
-    return [self verifySignatureFromBlsKeyPair:keyPair: messages withError:errorPtr];
+/**
+* @Verifies the BBS signature from a BLS12-381 G2 key pair
+*/
+- (bool)blsVerify:(Bls12381G2KeyPair* _Nonnull)keyPair
+         messages:(NSArray* _Nonnull)messages
+        withError:(NSError *_Nullable*_Nullable)errorPtr {
+    
+    return [self verifySignatureFromBlsKeyPair:keyPair
+                                      messages:messages
+                                     withError:errorPtr];
 }
 
-/** @brief Initializes a key pair */
-- (nullable instancetype)createFromBytes:(NSData* _Nonnull)bytes withError:(NSError *_Nullable*_Nullable)errorPtr {
+- (nullable instancetype)createFromBytes:(NSData* _Nonnull)bytes
+                               withError:(NSError *_Nullable*_Nullable)errorPtr {
+    
     self.value = [[NSData alloc] initWithData:bytes];
     return self;
 }
 
-/** @brief Initializes a key pair */
-- (bool)verifySignatureFromBlsKeyPair:(Bls12381G2KeyPair* _Nonnull)keyPair : (NSArray* _Nonnull)messages withError:(NSError *_Nullable*_Nullable)errorPtr {
-    BbsKeyPair * bbsKeyPair = [[BbsKeyPair alloc] initWithBls12381G2KeyPair:keyPair :messages.count withError:errorPtr];
+- (bool)verifySignatureFromBlsKeyPair:(Bls12381G2KeyPair* _Nonnull)keyPair
+                             messages:(NSArray* _Nonnull)messages withError:(NSError *_Nullable*_Nullable)errorPtr {
+    
+    BbsKeyPair * bbsKeyPair = [[BbsKeyPair alloc] initWithBls12381G2KeyPair:keyPair
+                                                               messageCount:messages.count
+                                                                  withError:errorPtr];
     
     if (bbsKeyPair == nil) {
         //TODO review
-        *errorPtr = [NSError errorWithDomain:@"bbs-signatures" code:1 userInfo:nil];
+        *errorPtr = [NSError errorWithDomain:@"bbs-signatures"
+                                        code:1
+                                    userInfo:nil];
         return false;
     }
     
-    return [self verifySignature:bbsKeyPair :messages withError:errorPtr];
+    return [self verifySignature:bbsKeyPair
+                        messages:messages
+                       withError:errorPtr];
 }
 
-/** @brief Initializes a key pair */
-- (bool)verifySignature:(BbsKeyPair* _Nonnull)keyPair : (NSArray* _Nonnull)messages withError:(NSError *_Nullable*_Nullable)errorPtr {
+- (bool)verifySignature:(BbsKeyPair* _Nonnull)keyPair
+               messages:(NSArray* _Nonnull)messages
+              withError:(NSError *_Nullable*_Nullable)errorPtr {
+    
     bbs_signature_error_t *err = (bbs_signature_error_t*) malloc(sizeof(bbs_signature_error_t));
     
     uint64_t verifySignatureHandle = bbs_sign_context_init(err);
@@ -114,8 +158,13 @@
     return true;
 }
 
-- (void) createSignatureFromBls12381G2:(Bls12381G2KeyPair* _Nonnull)keyPair : (NSArray* _Nonnull)messages withError:(NSError **)errorPtr {
-    BbsKeyPair * bbsKeyPair = [[BbsKeyPair alloc] initWithBls12381G2KeyPair:keyPair :messages.count withError:errorPtr];
+- (void) createSignatureFromBls12381G2:(Bls12381G2KeyPair* _Nonnull)keyPair
+                              messages:(NSArray* _Nonnull)messages
+                             withError:(NSError **)errorPtr {
+    
+    BbsKeyPair * bbsKeyPair = [[BbsKeyPair alloc] initWithBls12381G2KeyPair:keyPair
+                                                               messageCount:messages.count
+                                                                  withError:errorPtr];
     
     if (bbsKeyPair == nil) {
         //TODO review
@@ -123,11 +172,16 @@
         return;
     }
     
-    [self createSignature: bbsKeyPair : messages withError:errorPtr];
+    [self createSignature:bbsKeyPair
+                 messages:messages
+                withError:errorPtr];
     return;
 }
 
-- (void) createSignature:(BbsKeyPair* _Nonnull)keyPair : (NSArray* _Nonnull)messages withError:(NSError **)errorPtr {
+- (void) createSignature:(BbsKeyPair* _Nonnull)keyPair
+                messages:(NSArray* _Nonnull)messages
+               withError:(NSError **)errorPtr {
+    
     bbs_signature_error_t *err = (bbs_signature_error_t*) malloc(sizeof(bbs_signature_error_t));
     
     uint64_t createSignatureHandle = bbs_sign_context_init(err);
@@ -174,7 +228,9 @@
     }
     
     free(err);
-    self.value = [[NSData alloc] initWithBytesNoCopy:signature->data length:(NSUInteger)signature->len freeWhenDone:true];
+    self.value = [[NSData alloc] initWithBytesNoCopy:signature->data
+                                              length:(NSUInteger)signature->len
+                                        freeWhenDone:true];
 }
 
 @end

--- a/wrappers/obj-c/bbs-signatures/bbs_signature.m
+++ b/wrappers/obj-c/bbs-signatures/bbs_signature.m
@@ -49,7 +49,7 @@
 
 /** @brief Initializes a key pair */
 - (bool)verifySignatureFromBlsKeyPair:(Bls12381G2KeyPair* _Nonnull)keyPair : (NSArray* _Nonnull)messages withError:(NSError *_Nullable*_Nullable)errorPtr {
-    BbsKeyPair * bbsKeyPair = [[BbsKeyPair alloc] initFromBls12381G2KeyPair:keyPair :messages.count withError:errorPtr];
+    BbsKeyPair * bbsKeyPair = [[BbsKeyPair alloc] initWithBls12381G2KeyPair:keyPair :messages.count withError:errorPtr];
     
     if (bbsKeyPair == nil) {
         //TODO review
@@ -115,7 +115,7 @@
 }
 
 - (void) createSignatureFromBls12381G2:(Bls12381G2KeyPair* _Nonnull)keyPair : (NSArray* _Nonnull)messages withError:(NSError **)errorPtr {
-    BbsKeyPair * bbsKeyPair = [[BbsKeyPair alloc] initFromBls12381G2KeyPair:keyPair :messages.count withError:errorPtr];
+    BbsKeyPair * bbsKeyPair = [[BbsKeyPair alloc] initWithBls12381G2KeyPair:keyPair :messages.count withError:errorPtr];
     
     if (bbsKeyPair == nil) {
         //TODO review

--- a/wrappers/obj-c/bbs-signatures/bbs_signature.m
+++ b/wrappers/obj-c/bbs-signatures/bbs_signature.m
@@ -1,0 +1,180 @@
+#import <Foundation/Foundation.h>
+
+#import "bbs_signature.h"
+#import "BbsSignatureError.h"
+
+@interface BbsSignature ()
+
+/** @brief signature */
+@property(nonatomic, readwrite) NSData *value;
+
+@end
+
+/** @brief A BBS Signature */
+@implementation BbsSignature
+
+/** @brief Creates a BBS signature from the raw bytes  */
+- (nullable instancetype)initWithBytes:(NSData* _Nonnull)bytes withError:(NSError *_Nullable*_Nullable)errorPtr {
+    [self createFromBytes:bytes withError:errorPtr];
+    return self;
+}
+
+/** @brief Initializes a key pair */
+- (nullable instancetype)sign:(BbsKeyPair* _Nonnull)keyPair : (NSArray* _Nonnull)messages withError:(NSError *_Nullable*_Nullable)errorPtr {
+    [self createSignature: keyPair : messages withError:errorPtr];
+    return self;
+}
+
+/** @brief Initializes a key pair */
+- (bool)verify:(BbsKeyPair* _Nonnull)keyPair : (NSArray* _Nonnull)messages withError:(NSError *_Nullable*_Nullable)errorPtr {
+    return [self verifySignature:keyPair: messages withError:errorPtr];
+}
+
+/** @brief Initializes a key pair */
+- (nullable instancetype)blsSign:(Bls12381G2KeyPair* _Nonnull)keyPair : (NSArray* _Nonnull)messages withError:(NSError *_Nullable*_Nullable)errorPtr {
+    [self createSignatureFromBls12381G2: keyPair : messages withError:errorPtr];
+    return self;
+}
+
+/** @brief Initializes a key pair */
+- (bool)blsVerify:(Bls12381G2KeyPair* _Nonnull)keyPair : (NSArray* _Nonnull)messages withError:(NSError *_Nullable*_Nullable)errorPtr {
+    return [self verifySignatureFromBlsKeyPair:keyPair: messages withError:errorPtr];
+}
+
+/** @brief Initializes a key pair */
+- (nullable instancetype)createFromBytes:(NSData* _Nonnull)bytes withError:(NSError *_Nullable*_Nullable)errorPtr {
+    self.value = [[NSData alloc] initWithData:bytes];
+    return self;
+}
+
+/** @brief Initializes a key pair */
+- (bool)verifySignatureFromBlsKeyPair:(Bls12381G2KeyPair* _Nonnull)keyPair : (NSArray* _Nonnull)messages withError:(NSError *_Nullable*_Nullable)errorPtr {
+    BbsKeyPair * bbsKeyPair = [[BbsKeyPair alloc] initFromBls12381G2KeyPair:keyPair :messages.count withError:errorPtr];
+    
+    if (bbsKeyPair == nil) {
+        //TODO review
+        *errorPtr = [NSError errorWithDomain:@"bbs-signatures" code:1 userInfo:nil];
+        return false;
+    }
+    
+    return [self verifySignature:bbsKeyPair :messages withError:errorPtr];
+}
+
+/** @brief Initializes a key pair */
+- (bool)verifySignature:(BbsKeyPair* _Nonnull)keyPair : (NSArray* _Nonnull)messages withError:(NSError *_Nullable*_Nullable)errorPtr {
+    bbs_signature_error_t *err = (bbs_signature_error_t*) malloc(sizeof(bbs_signature_error_t));
+    
+    uint64_t verifySignatureHandle = bbs_sign_context_init(err);
+    
+    if (verifySignatureHandle == 0) {
+        *errorPtr = [BbsSignatureError errorFromBbsSignatureError:err];
+        return false;
+    }
+    
+    if (messages.count == 0){
+        *errorPtr = [BbsSignatureError errorFromBbsSignatureError:err];
+        return false;
+    }
+    
+    for (NSData *message in messages) {
+        bbs_signature_byte_buffer_t messageBuffer;
+        messageBuffer.len = message.length;
+        messageBuffer.data = (uint8_t *)message.bytes;
+        
+        if (bbs_verify_context_add_message_bytes(verifySignatureHandle, messageBuffer, err) != 0) {
+            *errorPtr = [BbsSignatureError errorFromBbsSignatureError:err];
+            return false;
+        }
+    }
+    
+    bbs_signature_byte_buffer_t publicKeyBuffer;
+    publicKeyBuffer.len = keyPair.publicKey.length;
+    publicKeyBuffer.data = (uint8_t *)keyPair.publicKey.bytes;
+
+    if (bbs_verify_context_set_public_key(verifySignatureHandle, publicKeyBuffer, err) != 0) {
+        *errorPtr = [BbsSignatureError errorFromBbsSignatureError:err];
+        return false;
+    }
+    
+    bbs_signature_byte_buffer_t signatureBuffer;
+    signatureBuffer.len = self.value.length;
+    signatureBuffer.data = (uint8_t *)self.value.bytes;
+
+    if (bbs_verify_context_set_signature(verifySignatureHandle, signatureBuffer, err) != 0) {
+        *errorPtr = [BbsSignatureError errorFromBbsSignatureError:err];
+        return false;
+    }
+    
+    if (bbs_verify_context_finish(verifySignatureHandle, err) != 1) {
+        *errorPtr = [BbsSignatureError errorFromBbsSignatureError:err];
+        return false;
+    }
+    
+    free(err);
+    return true;
+}
+
+- (void) createSignatureFromBls12381G2:(Bls12381G2KeyPair* _Nonnull)keyPair : (NSArray* _Nonnull)messages withError:(NSError **)errorPtr {
+    BbsKeyPair * bbsKeyPair = [[BbsKeyPair alloc] initFromBls12381G2KeyPair:keyPair :messages.count withError:errorPtr];
+    
+    if (bbsKeyPair == nil) {
+        //TODO review
+        *errorPtr = [NSError errorWithDomain:@"bbs-signatures" code:1 userInfo:nil];
+        return;
+    }
+    
+    [self createSignature: bbsKeyPair : messages withError:errorPtr];
+    return;
+}
+
+- (void) createSignature:(BbsKeyPair* _Nonnull)keyPair : (NSArray* _Nonnull)messages withError:(NSError **)errorPtr {
+    bbs_signature_error_t *err = (bbs_signature_error_t*) malloc(sizeof(bbs_signature_error_t));
+    
+    uint64_t createSignatureHandle = bbs_sign_context_init(err);
+    
+    if (createSignatureHandle == 0) {
+        *errorPtr = [BbsSignatureError errorFromBbsSignatureError:err];
+        return;
+    }
+    
+    for (NSData *message in messages) {
+        bbs_signature_byte_buffer_t messageBuffer;
+        messageBuffer.len = message.length;
+        messageBuffer.data = (uint8_t *)message.bytes;
+        
+        if (bbs_sign_context_add_message_bytes(createSignatureHandle, messageBuffer, err) > 0) {
+            *errorPtr = [BbsSignatureError errorFromBbsSignatureError:err];
+            return;
+        }
+    }
+    
+    bbs_signature_byte_buffer_t secretKeyBuffer;
+    secretKeyBuffer.len = keyPair.secretKey.length;
+    secretKeyBuffer.data = (uint8_t *)keyPair.secretKey.bytes;
+
+    if (bbs_sign_context_set_secret_key(createSignatureHandle, secretKeyBuffer, err) > 0) {
+        *errorPtr = [BbsSignatureError errorFromBbsSignatureError:err];
+        return;
+    }
+    
+    bbs_signature_byte_buffer_t publicKeyBuffer;
+    publicKeyBuffer.len = keyPair.publicKey.length;
+    publicKeyBuffer.data = (uint8_t *)keyPair.publicKey.bytes;
+
+    if (bbs_sign_context_set_public_key(createSignatureHandle, publicKeyBuffer, err) > 0) {
+        *errorPtr = [BbsSignatureError errorFromBbsSignatureError:err];
+        return;
+    }
+    
+    bbs_signature_byte_buffer_t *signature = (bbs_signature_byte_buffer_t*) malloc(sizeof(bbs_signature_byte_buffer_t));
+    
+    if (bbs_sign_context_finish(createSignatureHandle, signature, err) > 0) {
+        *errorPtr = [BbsSignatureError errorFromBbsSignatureError:err];
+        return;
+    }
+    
+    free(err);
+    self.value = [[NSData alloc] initWithBytesNoCopy:signature->data length:(NSUInteger)signature->len freeWhenDone:true];
+}
+
+@end

--- a/wrappers/obj-c/bbs-signatures/bbs_signature_proof.h
+++ b/wrappers/obj-c/bbs-signatures/bbs_signature_proof.h
@@ -3,34 +3,53 @@
 
 #import "bbs_signatures.h"
 
+/** @brief BBS Signature Proof */
 @interface BbsSignatureProof : NSObject
 
-/** @brief signature */
+/** @brief proof */
 @property(nonatomic, readonly) NSData *_Nonnull value;
+
 /**
 * @brief Creates a BBS signature proof from the raw bytes
 */
-- (nullable instancetype)initWithBytes:(NSData* _Nonnull)bytes withError:(NSError *_Nullable*_Nullable)errorPtr;
+- (nullable instancetype)initWithBytes:(NSData* _Nonnull)bytes
+                             withError:(NSError *_Nullable*_Nullable)errorPtr;
 
 /**
 * @brief Creates a BBS signature proof
 */
-- (nullable instancetype)createProof:(BbsSignature* _Nonnull)signature : (BbsKeyPair* _Nonnull)keyPair : (NSData* _Nonnull)nonce : (NSArray* _Nonnull)messages : (NSArray* _Nonnull)revealed withError:(NSError*_Nullable*_Nullable)errorPtr;
+- (nullable instancetype)createProof:(BbsSignature* _Nonnull)signature
+                             keyPair: (BbsKeyPair* _Nonnull)keyPair
+                               nonce:(NSData* _Nonnull)nonce
+                            messages:(NSArray* _Nonnull)messages
+                            revealed:(NSArray* _Nonnull)revealed
+                           withError:(NSError*_Nullable*_Nullable)errorPtr;
 
 /**
 * @brief Creates a BBS signature proof
 */
-- (nullable instancetype)blsCreateProof:(BbsSignature* _Nonnull)signature : (Bls12381G2KeyPair* _Nonnull)keyPair : (NSData* _Nonnull)nonce : (NSArray* _Nonnull)messages : (NSArray* _Nonnull)revealed withError:(NSError*_Nullable*_Nullable)errorPtr;
+- (nullable instancetype)blsCreateProof:(BbsSignature* _Nonnull)signature
+                                keyPair:(Bls12381G2KeyPair* _Nonnull)keyPair
+                                  nonce:(NSData* _Nonnull)nonce
+                               messages:(NSArray* _Nonnull)messages
+                               revealed:(NSArray* _Nonnull)revealed
+                              withError:(NSError*_Nullable*_Nullable)errorPtr;
 
 /**
 * @Verifies the BBS signature proof
 */
-- (bool)verifyProof:(BbsKeyPair* _Nonnull)keyPair : (NSArray* _Nonnull)messages : (NSData* _Nonnull)nonce withError:(NSError *_Nullable*_Nullable)errorPtr;
+- (bool)verifyProof:(BbsKeyPair* _Nonnull)keyPair
+           messages:(NSArray* _Nonnull)messages
+              nonce:(NSData* _Nonnull)nonce
+          withError:(NSError *_Nullable*_Nullable)errorPtr;
 
 /**
 * @Verifies the BBS signature proof from a BLS12-381 G2 key pair
 */
-- (bool)blsVerifyProof:(Bls12381G2KeyPair* _Nonnull)keyPair : (NSArray* _Nonnull)messages : (NSData* _Nonnull)nonce withError:(NSError *_Nullable*_Nullable)errorPtr;
+- (bool)blsVerifyProof:(Bls12381G2KeyPair* _Nonnull)keyPair
+              messages:(NSArray* _Nonnull)messages
+                 nonce:(NSData* _Nonnull)nonce
+             withError:(NSError *_Nullable*_Nullable)errorPtr;
 
 @end
 

--- a/wrappers/obj-c/bbs-signatures/bbs_signature_proof.h
+++ b/wrappers/obj-c/bbs-signatures/bbs_signature_proof.h
@@ -1,0 +1,37 @@
+#ifndef bbs_signature_proof_h
+#define bbs_signature_proof_h
+
+#import "bbs_signatures.h"
+
+@interface BbsSignatureProof : NSObject
+
+/** @brief signature */
+@property(nonatomic, readonly) NSData *_Nonnull value;
+/**
+* @brief Creates a BBS signature proof from the raw bytes
+*/
+- (nullable instancetype)initWithBytes:(NSData* _Nonnull)bytes withError:(NSError *_Nullable*_Nullable)errorPtr;
+
+/**
+* @brief Creates a BBS signature proof
+*/
+- (nullable instancetype)createProof:(BbsSignature* _Nonnull)signature : (BbsKeyPair* _Nonnull)keyPair : (NSData* _Nonnull)nonce : (NSArray* _Nonnull)messages : (NSArray* _Nonnull)revealed withError:(NSError*_Nullable*_Nullable)errorPtr;
+
+/**
+* @brief Creates a BBS signature proof
+*/
+- (nullable instancetype)blsCreateProof:(BbsSignature* _Nonnull)signature : (Bls12381G2KeyPair* _Nonnull)keyPair : (NSData* _Nonnull)nonce : (NSArray* _Nonnull)messages : (NSArray* _Nonnull)revealed withError:(NSError*_Nullable*_Nullable)errorPtr;
+
+/**
+* @Verifies the BBS signature proof
+*/
+- (bool)verifyProof:(BbsKeyPair* _Nonnull)keyPair : (NSArray* _Nonnull)messages : (NSData* _Nonnull)nonce withError:(NSError *_Nullable*_Nullable)errorPtr;
+
+/**
+* @Verifies the BBS signature proof from a BLS12-381 G2 key pair
+*/
+- (bool)blsVerifyProof:(Bls12381G2KeyPair* _Nonnull)keyPair : (NSArray* _Nonnull)messages : (NSData* _Nonnull)nonce withError:(NSError *_Nullable*_Nullable)errorPtr;
+
+@end
+
+#endif /* bbs_signature_proof_h */

--- a/wrappers/obj-c/bbs-signatures/bbs_signature_proof.h
+++ b/wrappers/obj-c/bbs-signatures/bbs_signature_proof.h
@@ -1,7 +1,9 @@
 #ifndef bbs_signature_proof_h
 #define bbs_signature_proof_h
 
-#import "bbs_signatures.h"
+#import "bbs_key_pair.h"
+#import "bbs_signature.h"
+#import "bls12381g2_key_pair.h"
 
 /** @brief BBS Signature Proof */
 @interface BbsSignatureProof : NSObject
@@ -19,7 +21,7 @@
 * @brief Creates a BBS signature proof
 */
 - (nullable instancetype)createProof:(BbsSignature* _Nonnull)signature
-                             keyPair: (BbsKeyPair* _Nonnull)keyPair
+                             keyPair:(BbsKeyPair* _Nonnull)keyPair
                                nonce:(NSData* _Nonnull)nonce
                             messages:(NSArray* _Nonnull)messages
                             revealed:(NSArray* _Nonnull)revealed

--- a/wrappers/obj-c/bbs-signatures/bbs_signature_proof.m
+++ b/wrappers/obj-c/bbs-signatures/bbs_signature_proof.m
@@ -16,40 +16,87 @@
 @implementation BbsSignatureProof
 
 /** @brief Creates a BBS signature proof from the raw bytes  */
-- (nullable instancetype)initWithBytes:(NSData* _Nonnull)bytes withError:(NSError *_Nullable*_Nullable)errorPtr {
-    [self createFromBytes:bytes withError:errorPtr];
+- (nullable instancetype)initWithBytes:(NSData* _Nonnull)bytes
+                             withError:(NSError *_Nullable*_Nullable)errorPtr {
+    
+    [self createFromBytes:bytes
+                withError:errorPtr];
     return self;
 }
 
 /** @brief Creates a BBS signature proof */
-- (nullable instancetype)createProof:(BbsSignature* _Nonnull)signature : (BbsKeyPair* _Nonnull)keyPair : (NSData* _Nonnull)nonce : (NSArray* _Nonnull)messages : (NSArray* _Nonnull)revealed withError:(NSError*_Nullable*_Nullable)errorPtr {
-    [self createSignatureProof: signature : keyPair : nonce : messages : revealed withError:errorPtr];
+- (nullable instancetype)createProof:(BbsSignature* _Nonnull)signature
+                             keyPair:(BbsKeyPair* _Nonnull)keyPair
+                               nonce:(NSData* _Nonnull)nonce
+                            messages:(NSArray* _Nonnull)messages
+                            revealed:(NSArray* _Nonnull)revealed
+                           withError:(NSError*_Nullable*_Nullable)errorPtr {
+    
+    [self createSignatureProof:signature
+                       keyPair:keyPair
+                         nonce:nonce
+                      messages:messages
+                      revealed:revealed
+                     withError:errorPtr];
     return self;
 }
 
 /** @brief Creates a BBS signature proof  from a BLS12-381G2 public key */
-- (nullable instancetype)blsCreateProof:(BbsSignature* _Nonnull)signature : (Bls12381G2KeyPair* _Nonnull)keyPair : (NSData* _Nonnull)nonce : (NSArray* _Nonnull)messages : (NSArray* _Nonnull)revealed withError:(NSError*_Nullable*_Nullable)errorPtr {
-    [self createSignatureProofFromBls12381G2: signature : keyPair : nonce : messages : revealed withError:errorPtr];
+- (nullable instancetype)blsCreateProof:(BbsSignature* _Nonnull)signature
+                                keyPair:(Bls12381G2KeyPair* _Nonnull)keyPair
+                                  nonce:(NSData* _Nonnull)nonce
+                               messages:(NSArray* _Nonnull)messages
+                               revealed:(NSArray* _Nonnull)revealed
+                              withError:(NSError*_Nullable*_Nullable)errorPtr {
+    
+    [self createSignatureProofFromBls12381G2:signature
+                                     keyPair:keyPair
+                                       nonce:nonce
+                                    messages:messages
+                                    revealed:revealed
+                                   withError:errorPtr];
     return self;
 }
 
 /** @brief Initializes a key pair */
-- (bool)verifyProof:(BbsKeyPair* _Nonnull)keyPair : (NSArray* _Nonnull)messages : (NSData* _Nonnull)nonce withError:(NSError *_Nullable*_Nullable)errorPtr {
-    return [self verifySignatureProof:keyPair: messages: nonce withError:errorPtr];
+- (bool)verifyProof:(BbsKeyPair* _Nonnull)keyPair
+           messages:(NSArray* _Nonnull)messages
+              nonce:(NSData* _Nonnull)nonce
+          withError:(NSError *_Nullable*_Nullable)errorPtr {
+    
+    return [self verifySignatureProof:keyPair
+                             messages:messages
+                                nonce:nonce
+                            withError:errorPtr];
 }
 
 /** @brief Initializes a key pair */
-- (bool)blsVerifyProof:(Bls12381G2KeyPair* _Nonnull)keyPair : (NSArray* _Nonnull)messages : (NSData* _Nonnull)nonce withError:(NSError *_Nullable*_Nullable)errorPtr {
-    return [self verifySignatureProofFromBls12381G2:keyPair: messages: nonce withError:errorPtr];
+- (bool)blsVerifyProof:(Bls12381G2KeyPair* _Nonnull)keyPair
+              messages:(NSArray* _Nonnull)messages
+                 nonce:(NSData* _Nonnull)nonce
+             withError:(NSError *_Nullable*_Nullable)errorPtr {
+    
+    return [self verifySignatureProofFromBls12381G2:keyPair
+                                           messages:messages
+                                              nonce:nonce
+                                          withError:errorPtr];
 }
 
 /** @brief Initializes a key pair */
-- (nullable instancetype)createFromBytes:(NSData* _Nonnull)bytes withError:(NSError *_Nullable*_Nullable)errorPtr {
+- (nullable instancetype)createFromBytes:(NSData* _Nonnull)bytes
+                               withError:(NSError *_Nullable*_Nullable)errorPtr {
+    
     self.value = [[NSData alloc] initWithData:bytes];
     return self;
 }
 
-- (void) createSignatureProof:(BbsSignature* _Nonnull)signature : (BbsKeyPair* _Nonnull)keyPair : (NSData* _Nonnull)nonce : (NSArray* _Nonnull)messages : (NSArray* _Nonnull)revealed withError:(NSError*_Nullable*_Nullable)errorPtr {
+- (void) createSignatureProof:(BbsSignature* _Nonnull)signature
+                      keyPair:(BbsKeyPair* _Nonnull)keyPair
+                        nonce:(NSData* _Nonnull)nonce
+                     messages:(NSArray* _Nonnull)messages
+                     revealed:(NSArray* _Nonnull)revealed
+                    withError:(NSError*_Nullable*_Nullable)errorPtr {
+    
     bbs_signature_error_t *err = (bbs_signature_error_t*) malloc(sizeof(bbs_signature_error_t));
     
     uint64_t createProofHandle = bbs_create_proof_context_init(err);
@@ -70,7 +117,6 @@
         
         Boolean isRevealed = [revealed containsObject:[[NSNumber alloc] initWithInt:i]];
         
-        //TODO need to revist this
         bbs_signature_proof_message_t messageRevealType;
         
         if (isRevealed) {
@@ -122,13 +168,23 @@
         return;
     }
     
-    self.value = [[NSData alloc] initWithBytesNoCopy:proof->data length:(NSUInteger)proof->len freeWhenDone:true];
+    self.value = [[NSData alloc] initWithBytesNoCopy:proof->data
+                                              length:(NSUInteger)proof->len
+                                        freeWhenDone:true];
     
     free(err);
 }
 
-- (void) createSignatureProofFromBls12381G2:(BbsSignature* _Nonnull)signature : (Bls12381G2KeyPair* _Nonnull)keyPair : (NSData* _Nonnull)nonce : (NSArray* _Nonnull)messages : (NSArray* _Nonnull)revealed withError:(NSError*_Nullable*_Nullable)errorPtr {
-    BbsKeyPair * bbsKeyPair = [[BbsKeyPair alloc] initWithBls12381G2KeyPair:keyPair :messages.count withError:errorPtr];
+- (void) createSignatureProofFromBls12381G2:(BbsSignature* _Nonnull)signature
+                                    keyPair:(Bls12381G2KeyPair* _Nonnull)keyPair
+                                      nonce:(NSData* _Nonnull)nonce
+                                   messages:(NSArray* _Nonnull)messages
+                                   revealed:(NSArray* _Nonnull)revealed
+                                  withError:(NSError*_Nullable*_Nullable)errorPtr {
+    
+    BbsKeyPair * bbsKeyPair = [[BbsKeyPair alloc] initWithBls12381G2KeyPair:keyPair
+                                                               messageCount:messages.count
+                                                                  withError:errorPtr];
     
     if (bbsKeyPair == nil) {
         //TODO review
@@ -136,12 +192,21 @@
         return;
     }
     
-    [self createSignatureProof: signature : bbsKeyPair : nonce : messages : revealed withError:errorPtr];
+    [self createSignatureProof:signature
+                       keyPair:bbsKeyPair
+                         nonce:nonce
+                      messages:messages
+                      revealed:revealed
+                     withError:errorPtr];
     return;
 }
 
 /** @brief Initializes a key pair */
-- (bool)verifySignatureProof:(BbsKeyPair* _Nonnull)keyPair : (NSArray* _Nonnull)messages : (NSData* _Nonnull)nonce withError:(NSError *_Nullable*_Nullable)errorPtr {
+- (bool)verifySignatureProof:(BbsKeyPair* _Nonnull)keyPair
+                    messages:(NSArray* _Nonnull)messages
+                       nonce:(NSData* _Nonnull)nonce
+                   withError:(NSError *_Nullable*_Nullable)errorPtr {
+    
     bbs_signature_error_t *err = (bbs_signature_error_t*) malloc(sizeof(bbs_signature_error_t));
     
     uint64_t verifyProofHandle = bbs_verify_proof_context_init(err);
@@ -204,8 +269,14 @@
 }
 
 /** @brief Initializes a key pair */
-- (bool)verifySignatureProofFromBls12381G2:(Bls12381G2KeyPair* _Nonnull)keyPair : (NSArray* _Nonnull)messages : (NSData* _Nonnull)nonce withError:(NSError *_Nullable*_Nullable)errorPtr {
-    BbsKeyPair * bbsKeyPair = [[BbsKeyPair alloc] initWithBls12381G2KeyPair:keyPair :messages.count withError:errorPtr];
+- (bool)verifySignatureProofFromBls12381G2:(Bls12381G2KeyPair* _Nonnull)keyPair
+                                  messages:(NSArray* _Nonnull)messages
+                                     nonce:(NSData* _Nonnull)nonce
+                                 withError:(NSError *_Nullable*_Nullable)errorPtr {
+    
+    BbsKeyPair * bbsKeyPair = [[BbsKeyPair alloc] initWithBls12381G2KeyPair:keyPair
+                                                               messageCount:messages.count
+                                                                  withError:errorPtr];
     
     if (bbsKeyPair == nil) {
         //TODO review
@@ -213,7 +284,10 @@
         return false;
     }
     
-    return [self verifySignatureProof:bbsKeyPair :messages :nonce withError:errorPtr];
+    return [self verifySignatureProof:bbsKeyPair
+                             messages:messages
+                                nonce:nonce
+                            withError:errorPtr];
 }
 
 @end

--- a/wrappers/obj-c/bbs-signatures/bbs_signature_proof.m
+++ b/wrappers/obj-c/bbs-signatures/bbs_signature_proof.m
@@ -1,0 +1,219 @@
+#import <Foundation/Foundation.h>
+
+#import "bbs.h"
+#import "bbs_signature_proof.h"
+#import "bbs_signatures.h"
+#import "BbsSignatureError.h"
+
+@interface BbsSignatureProof ()
+
+/** @brief A BBS Signature Proof */
+@property(nonatomic, readwrite) NSData *value;
+
+@end
+
+/** @brief A BBS Signature Proof */
+@implementation BbsSignatureProof
+
+/** @brief Creates a BBS signature proof from the raw bytes  */
+- (nullable instancetype)initWithBytes:(NSData* _Nonnull)bytes withError:(NSError *_Nullable*_Nullable)errorPtr {
+    [self createFromBytes:bytes withError:errorPtr];
+    return self;
+}
+
+/** @brief Creates a BBS signature proof */
+- (nullable instancetype)createProof:(BbsSignature* _Nonnull)signature : (BbsKeyPair* _Nonnull)keyPair : (NSData* _Nonnull)nonce : (NSArray* _Nonnull)messages : (NSArray* _Nonnull)revealed withError:(NSError*_Nullable*_Nullable)errorPtr {
+    [self createSignatureProof: signature : keyPair : nonce : messages : revealed withError:errorPtr];
+    return self;
+}
+
+/** @brief Creates a BBS signature proof  from a BLS12-381G2 public key */
+- (nullable instancetype)blsCreateProof:(BbsSignature* _Nonnull)signature : (Bls12381G2KeyPair* _Nonnull)keyPair : (NSData* _Nonnull)nonce : (NSArray* _Nonnull)messages : (NSArray* _Nonnull)revealed withError:(NSError*_Nullable*_Nullable)errorPtr {
+    [self createSignatureProofFromBls12381G2: signature : keyPair : nonce : messages : revealed withError:errorPtr];
+    return self;
+}
+
+/** @brief Initializes a key pair */
+- (bool)verifyProof:(BbsKeyPair* _Nonnull)keyPair : (NSArray* _Nonnull)messages : (NSData* _Nonnull)nonce withError:(NSError *_Nullable*_Nullable)errorPtr {
+    return [self verifySignatureProof:keyPair: messages: nonce withError:errorPtr];
+}
+
+/** @brief Initializes a key pair */
+- (bool)blsVerifyProof:(Bls12381G2KeyPair* _Nonnull)keyPair : (NSArray* _Nonnull)messages : (NSData* _Nonnull)nonce withError:(NSError *_Nullable*_Nullable)errorPtr {
+    return [self verifySignatureProofFromBls12381G2:keyPair: messages: nonce withError:errorPtr];
+}
+
+/** @brief Initializes a key pair */
+- (nullable instancetype)createFromBytes:(NSData* _Nonnull)bytes withError:(NSError *_Nullable*_Nullable)errorPtr {
+    self.value = [[NSData alloc] initWithData:bytes];
+    return self;
+}
+
+- (void) createSignatureProof:(BbsSignature* _Nonnull)signature : (BbsKeyPair* _Nonnull)keyPair : (NSData* _Nonnull)nonce : (NSArray* _Nonnull)messages : (NSArray* _Nonnull)revealed withError:(NSError*_Nullable*_Nullable)errorPtr {
+    bbs_signature_error_t *err = (bbs_signature_error_t*) malloc(sizeof(bbs_signature_error_t));
+    
+    uint64_t createProofHandle = bbs_create_proof_context_init(err);
+    
+    if (createProofHandle == 0) {
+        *errorPtr = [BbsSignatureError errorFromBbsSignatureError:err];
+        return;
+    }
+    
+    int i = 0;
+    for (NSData *message in messages) {
+        bbs_signature_byte_buffer_t messageBuffer;
+        messageBuffer.len = message.length;
+        messageBuffer.data = (uint8_t *)message.bytes;
+        
+        bbs_signature_byte_buffer_t blindingFactor;
+        blindingFactor.len = 0;
+        
+        Boolean isRevealed = [revealed containsObject:[[NSNumber alloc] initWithInt:i]];
+        
+        //TODO need to revist this
+        bbs_signature_proof_message_t messageRevealType;
+        
+        if (isRevealed) {
+            messageRevealType = Revealed;
+        }
+        else {
+            messageRevealType = HiddenProofSpecificBlinding;
+        }
+        
+        if (bbs_create_proof_context_add_proof_message_bytes(createProofHandle, messageBuffer, messageRevealType, blindingFactor, err) > 0) {
+            *errorPtr = [BbsSignatureError errorFromBbsSignatureError:err];
+            return;
+        }
+        
+        i++;
+    }
+    
+    bbs_signature_byte_buffer_t signatureBuffer;
+    signatureBuffer.len = signature.value.length;
+    signatureBuffer.data = (uint8_t *)signature.value.bytes;
+
+    if (bbs_create_proof_context_set_signature(createProofHandle, signatureBuffer, err) > 0) {
+        *errorPtr = [BbsSignatureError errorFromBbsSignatureError:err];
+        return;
+    }
+    
+    bbs_signature_byte_buffer_t publicKeyBuffer;
+    publicKeyBuffer.len = keyPair.publicKey.length;
+    publicKeyBuffer.data = (uint8_t *)keyPair.publicKey.bytes;
+
+    if (bbs_create_proof_context_set_public_key(createProofHandle, publicKeyBuffer, err) > 0) {
+        *errorPtr = [BbsSignatureError errorFromBbsSignatureError:err];
+        return;
+    }
+    
+    bbs_signature_byte_buffer_t nonceBuffer;
+    nonceBuffer.len = nonce.length;
+    nonceBuffer.data = (uint8_t *)nonce.bytes;
+
+    if (bbs_create_proof_context_set_nonce_bytes(createProofHandle, nonceBuffer, err) > 0) {
+        *errorPtr = [BbsSignatureError errorFromBbsSignatureError:err];
+        return;
+    }
+    
+    bbs_signature_byte_buffer_t *proof = (bbs_signature_byte_buffer_t*) malloc(sizeof(bbs_signature_byte_buffer_t));
+    
+    if (bbs_create_proof_context_finish(createProofHandle, proof, err) != 0) {
+        *errorPtr = [BbsSignatureError errorFromBbsSignatureError:err];
+        return;
+    }
+    
+    self.value = [[NSData alloc] initWithBytesNoCopy:proof->data length:(NSUInteger)proof->len freeWhenDone:true];
+    
+    free(err);
+}
+
+- (void) createSignatureProofFromBls12381G2:(BbsSignature* _Nonnull)signature : (Bls12381G2KeyPair* _Nonnull)keyPair : (NSData* _Nonnull)nonce : (NSArray* _Nonnull)messages : (NSArray* _Nonnull)revealed withError:(NSError*_Nullable*_Nullable)errorPtr {
+    BbsKeyPair * bbsKeyPair = [[BbsKeyPair alloc] initFromBls12381G2KeyPair:keyPair :messages.count withError:errorPtr];
+    
+    if (bbsKeyPair == nil) {
+        //TODO review
+        *errorPtr = [NSError errorWithDomain:@"bbs-signatures" code:1 userInfo:nil];
+        return;
+    }
+    
+    [self createSignatureProof: signature : bbsKeyPair : nonce : messages : revealed withError:errorPtr];
+    return;
+}
+
+/** @brief Initializes a key pair */
+- (bool)verifySignatureProof:(BbsKeyPair* _Nonnull)keyPair : (NSArray* _Nonnull)messages : (NSData* _Nonnull)nonce withError:(NSError *_Nullable*_Nullable)errorPtr {
+    bbs_signature_error_t *err = (bbs_signature_error_t*) malloc(sizeof(bbs_signature_error_t));
+    
+    uint64_t verifyProofHandle = bbs_verify_proof_context_init(err);
+    
+    if (verifyProofHandle == 0) {
+        *errorPtr = [BbsSignatureError errorFromBbsSignatureError:err];
+        return false;
+    }
+    
+    if (messages.count == 0){
+        //TODO review
+        *errorPtr = [NSError errorWithDomain:@"bbs-signatures" code:err->code userInfo:@{@"Message": [NSString stringWithUTF8String:err->message]}];
+        return false;
+    }
+    
+    for (NSData *message in messages) {
+        bbs_signature_byte_buffer_t messageBuffer;
+        messageBuffer.len = message.length;
+        messageBuffer.data = (uint8_t *)message.bytes;
+        
+        if (bbs_verify_proof_context_add_message_bytes(verifyProofHandle, messageBuffer, err) > 0) {
+            *errorPtr = [BbsSignatureError errorFromBbsSignatureError:err];
+            return false;
+        }
+    }
+    
+    bbs_signature_byte_buffer_t publicKeyBuffer;
+    publicKeyBuffer.len = keyPair.publicKey.length;
+    publicKeyBuffer.data = (uint8_t *)keyPair.publicKey.bytes;
+
+    if (bbs_verify_proof_context_set_public_key(verifyProofHandle, publicKeyBuffer, err) > 0) {
+        *errorPtr = [BbsSignatureError errorFromBbsSignatureError:err];
+        return false;
+    }
+    
+    bbs_signature_byte_buffer_t nonceBuffer;
+    nonceBuffer.len = nonce.length;
+    nonceBuffer.data = (uint8_t *)nonce.bytes;
+
+    if (bbs_create_proof_context_set_nonce_bytes(verifyProofHandle, nonceBuffer, err) > 0) {
+        *errorPtr = [BbsSignatureError errorFromBbsSignatureError:err];
+        return false;
+    }
+    
+    bbs_signature_byte_buffer_t proofBuffer;
+    proofBuffer.len = self.value.length;
+    proofBuffer.data = (uint8_t *)self.value.bytes;
+
+    if (bbs_verify_proof_context_set_proof(verifyProofHandle, proofBuffer, err) > 0) {
+        *errorPtr = [BbsSignatureError errorFromBbsSignatureError:err];
+        return false;
+    }
+    
+    if (bbs_verify_proof_context_finish(verifyProofHandle, err) != 1) {
+        *errorPtr = [BbsSignatureError errorFromBbsSignatureError:err];
+        return false;
+    }
+    
+    return true;
+}
+
+/** @brief Initializes a key pair */
+- (bool)verifySignatureProofFromBls12381G2:(Bls12381G2KeyPair* _Nonnull)keyPair : (NSArray* _Nonnull)messages : (NSData* _Nonnull)nonce withError:(NSError *_Nullable*_Nullable)errorPtr {
+    BbsKeyPair * bbsKeyPair = [[BbsKeyPair alloc] initFromBls12381G2KeyPair:keyPair :messages.count withError:errorPtr];
+    
+    if (bbsKeyPair == nil) {
+        //TODO review
+        *errorPtr = [NSError errorWithDomain:@"bbs-signatures" code:1 userInfo:nil];
+        return false;
+    }
+    
+    return [self verifySignatureProof:bbsKeyPair :messages :nonce withError:errorPtr];
+}
+
+@end

--- a/wrappers/obj-c/bbs-signatures/bbs_signature_proof.m
+++ b/wrappers/obj-c/bbs-signatures/bbs_signature_proof.m
@@ -128,7 +128,7 @@
 }
 
 - (void) createSignatureProofFromBls12381G2:(BbsSignature* _Nonnull)signature : (Bls12381G2KeyPair* _Nonnull)keyPair : (NSData* _Nonnull)nonce : (NSArray* _Nonnull)messages : (NSArray* _Nonnull)revealed withError:(NSError*_Nullable*_Nullable)errorPtr {
-    BbsKeyPair * bbsKeyPair = [[BbsKeyPair alloc] initFromBls12381G2KeyPair:keyPair :messages.count withError:errorPtr];
+    BbsKeyPair * bbsKeyPair = [[BbsKeyPair alloc] initWithBls12381G2KeyPair:keyPair :messages.count withError:errorPtr];
     
     if (bbsKeyPair == nil) {
         //TODO review
@@ -205,7 +205,7 @@
 
 /** @brief Initializes a key pair */
 - (bool)verifySignatureProofFromBls12381G2:(Bls12381G2KeyPair* _Nonnull)keyPair : (NSArray* _Nonnull)messages : (NSData* _Nonnull)nonce withError:(NSError *_Nullable*_Nullable)errorPtr {
-    BbsKeyPair * bbsKeyPair = [[BbsKeyPair alloc] initFromBls12381G2KeyPair:keyPair :messages.count withError:errorPtr];
+    BbsKeyPair * bbsKeyPair = [[BbsKeyPair alloc] initWithBls12381G2KeyPair:keyPair :messages.count withError:errorPtr];
     
     if (bbsKeyPair == nil) {
         //TODO review

--- a/wrappers/obj-c/bbs-signatures/bbs_signature_proof.m
+++ b/wrappers/obj-c/bbs-signatures/bbs_signature_proof.m
@@ -2,7 +2,6 @@
 
 #import "bbs.h"
 #import "bbs_signature_proof.h"
-#import "bbs_signatures.h"
 #import "BbsSignatureError.h"
 
 @interface BbsSignatureProof ()

--- a/wrappers/obj-c/bbs-signatures/bbs_signatures.h
+++ b/wrappers/obj-c/bbs-signatures/bbs_signatures.h
@@ -1,0 +1,9 @@
+#ifndef bbs_signatures_h
+#define bbs_signatures_h
+
+#import "bls12381g2_key_pair.h"
+#import "bbs_key_pair.h"
+#import "bbs_signature.h"
+#import "bbs_signature_proof.h"
+
+#endif /* bbs_signatures_h */

--- a/wrappers/obj-c/bbs-signatures/bbs_signatures.h
+++ b/wrappers/obj-c/bbs-signatures/bbs_signatures.h
@@ -1,9 +1,0 @@
-#ifndef bbs_signatures_h
-#define bbs_signatures_h
-
-#import "bls12381g2_key_pair.h"
-#import "bbs_key_pair.h"
-#import "bbs_signature.h"
-#import "bbs_signature_proof.h"
-
-#endif /* bbs_signatures_h */

--- a/wrappers/obj-c/bbs-signatures/bls12381g2_key_pair.h
+++ b/wrappers/obj-c/bbs-signatures/bls12381g2_key_pair.h
@@ -1,0 +1,33 @@
+#ifndef bls12381_key_pair_h
+#define bls12381_key_pair_h
+
+#import <Foundation/Foundation.h>
+#import "bbs.h"
+
+/** @brief BLS 12-381 G2 key pair */
+@interface Bls12381G2KeyPair : NSObject
+
+/** @brief secret key */
+@property(nonatomic, readonly) NSData *_Nullable secretKey;
+
+/** @brief public key */
+@property(nonatomic, readonly) NSData *_Nonnull publicKey;
+
+/**
+* @brief initialise a BLS 12-381 G2 public key from data
+*/
+- (nullable instancetype)initFromPublicKey:(NSData* _Nonnull)data;
+
+/**
+* @brief initialise a BLS 12-381 G2 key pair by generating secretKey and publicKey
+*/
+- (nullable instancetype)initWithSeed:(NSData* _Nullable)seed withError:(NSError *_Nullable*_Nullable)errorPtr;
+
+/**
+* @brief initialise a BLS 12-381 G2 key pair from the secretKey
+*/
+- (nullable instancetype)initWithSecretKey:(NSData* _Nonnull)secretKey withError:(NSError *_Nullable*_Nullable)errorPtr;
+
+@end
+
+#endif /* bls12381_key_pair_h */

--- a/wrappers/obj-c/bbs-signatures/bls12381g2_key_pair.h
+++ b/wrappers/obj-c/bbs-signatures/bls12381g2_key_pair.h
@@ -1,5 +1,5 @@
-#ifndef bls12381_key_pair_h
-#define bls12381_key_pair_h
+#ifndef bls12381g2_key_pair_h
+#define bls12381g2_key_pair_h
 
 #import <Foundation/Foundation.h>
 #import "bbs.h"
@@ -14,20 +14,22 @@
 @property(nonatomic, readonly) NSData *_Nonnull publicKey;
 
 /**
-* @brief initialise a BLS 12-381 G2 public key from data
+* @brief Initialises a BLS 12-381 G2 public key from the raw bytes of the public key
 */
 - (nullable instancetype)initWithPublicKey:(NSData* _Nonnull)data;
 
 /**
-* @brief initialise a BLS 12-381 G2 key pair by generating secretKey and publicKey
+* @brief Generates a new BLS 12-381 G2 key pair by using an optionally supplied seed
 */
-- (nullable instancetype)initWithSeed:(NSData* _Nullable)seed withError:(NSError *_Nullable*_Nullable)errorPtr;
+- (nullable instancetype)initWithSeed:(NSData* _Nullable)seed
+                            withError:(NSError *_Nullable*_Nullable)errorPtr;
 
 /**
-* @brief initialise a BLS 12-381 G2 key pair from the secretKey
+* @brief initialise a BLS 12-381 G2 key pair  from the raw bytes of the secretKey
 */
-- (nullable instancetype)initWithSecretKey:(NSData* _Nonnull)secretKey withError:(NSError *_Nullable*_Nullable)errorPtr;
+- (nullable instancetype)initWithSecretKey:(NSData* _Nonnull)secretKey
+                                 withError:(NSError *_Nullable*_Nullable)errorPtr;
 
 @end
 
-#endif /* bls12381_key_pair_h */
+#endif /* bls12381g2_key_pair_h */

--- a/wrappers/obj-c/bbs-signatures/bls12381g2_key_pair.h
+++ b/wrappers/obj-c/bbs-signatures/bls12381g2_key_pair.h
@@ -16,7 +16,7 @@
 /**
 * @brief initialise a BLS 12-381 G2 public key from data
 */
-- (nullable instancetype)initFromPublicKey:(NSData* _Nonnull)data;
+- (nullable instancetype)initWithPublicKey:(NSData* _Nonnull)data;
 
 /**
 * @brief initialise a BLS 12-381 G2 key pair by generating secretKey and publicKey

--- a/wrappers/obj-c/bbs-signatures/bls12381g2_key_pair.m
+++ b/wrappers/obj-c/bbs-signatures/bls12381g2_key_pair.m
@@ -1,0 +1,83 @@
+#import "bls12381g2_key_pair.h"
+#import "BbsSignatureError.h"
+
+/** @brief BLS 12-381 G2 key pair */
+@interface Bls12381G2KeyPair ()
+
+/** @brief secret key */
+@property(nonatomic, readwrite) NSData *secretKey;
+
+/** @brief public key */
+@property(nonatomic, readwrite) NSData *publicKey;
+
+@end
+
+/** @brief Implementation of a BLS 12-381 G2 Key pair */
+@implementation Bls12381G2KeyPair
+
+- (nullable instancetype)initFromPublicKey:(NSData* _Nonnull)data {
+    self.publicKey = data;
+    return self;
+}
+
+/** @brief Initializes a key pair */
+- (nullable instancetype)initWithSeed:(NSData* _Nullable)seed withError:(NSError *_Nullable*_Nullable)errorPtr {
+    [self generateKeyPair: seed withError:errorPtr];
+    return self;
+}
+
+/** @brief Initializes a key pair from a secret key*/
+- (nullable instancetype)initWithSecretKey:(NSData* _Nonnull)secretKey withError:(NSError *_Nullable*_Nullable)errorPtr {
+    [self keyPairFromSecretKey: secretKey withError:errorPtr];
+    return self;
+}
+
+/** @brief Initializes a key pair from a public key*/
+- (nullable instancetype)initWithPublicKey:(NSData* _Nonnull)publicKey {
+    self.publicKey = [[NSData alloc] initWithData:publicKey];
+    return self;
+}
+
+- (void) generateKeyPair:(NSData* _Nullable)seed withError:(NSError *_Nullable*_Nullable)errorPtr {
+    //TODO deal with seed being null
+    bbs_signature_byte_buffer_t seedBuffer;
+    seedBuffer.len = seed.length;
+    seedBuffer.data = (uint8_t *)seed.bytes;
+    
+    bbs_signature_byte_buffer_t *publicKey = (bbs_signature_byte_buffer_t*) malloc(sizeof(bbs_signature_byte_buffer_t));
+    bbs_signature_byte_buffer_t *secretKey = (bbs_signature_byte_buffer_t*) malloc(sizeof(bbs_signature_byte_buffer_t));
+    bbs_signature_error_t *err = (bbs_signature_error_t*) malloc(sizeof(bbs_signature_error_t));
+
+    uint64_t handle = bls_generate_key(seedBuffer, publicKey, secretKey, err);
+    
+    if (handle > 0) {
+        *errorPtr = [BbsSignatureError errorFromBbsSignatureError:err];
+        return;
+    }
+    
+    self.publicKey = [[NSData alloc] initWithBytesNoCopy:publicKey->data length:(NSUInteger)publicKey->len freeWhenDone:true];
+    self.secretKey = [[NSData alloc] initWithBytesNoCopy:secretKey->data length:(NSUInteger)secretKey->len freeWhenDone:true];
+    
+    free(err);
+}
+
+- (void) keyPairFromSecretKey:(NSData* _Nonnull)secretKey withError:(NSError *_Nullable*_Nullable)errorPtr {
+    bbs_signature_byte_buffer_t secretKeyBuffer;
+    secretKeyBuffer.len = secretKey.length;
+    secretKeyBuffer.data = (uint8_t *)secretKey.bytes;
+    
+    //TODO handle when pointer is 0 e.g memory allocation failed
+    bbs_signature_byte_buffer_t *publicKey = (bbs_signature_byte_buffer_t*) malloc(sizeof(bbs_signature_byte_buffer_t));
+    bbs_signature_error_t *err = (bbs_signature_error_t*) malloc(sizeof(bbs_signature_error_t));
+    
+    if (bls_get_public_key(secretKeyBuffer, publicKey, err) > 0) {
+        *errorPtr = [BbsSignatureError errorFromBbsSignatureError:err];
+        return;
+    }
+    
+    self.publicKey = [[NSData alloc] initWithBytesNoCopy:publicKey->data length:(NSUInteger)publicKey->len freeWhenDone:true];
+    self.secretKey = [[NSData alloc] initWithData:secretKey];
+    
+    free(err);
+}
+@end

--- a/wrappers/obj-c/bbs-signatures/bls12381g2_key_pair.m
+++ b/wrappers/obj-c/bbs-signatures/bls12381g2_key_pair.m
@@ -12,28 +12,28 @@
 
 @end
 
-/** @brief Implementation of a BLS 12-381 G2 Key pair */
 @implementation Bls12381G2KeyPair
 
-/** @brief Initializes a key pair from a public key*/
 - (nullable instancetype)initWithPublicKey:(NSData* _Nonnull)publicKey {
     self.publicKey = [[NSData alloc] initWithData:publicKey];
     return self;
 }
 
-/** @brief Initializes a key pair */
-- (nullable instancetype)initWithSeed:(NSData* _Nullable)seed withError:(NSError *_Nullable*_Nullable)errorPtr {
+- (nullable instancetype)initWithSeed:(NSData* _Nullable)seed
+                            withError:(NSError *_Nullable*_Nullable)errorPtr {
     [self generateKeyPair: seed withError:errorPtr];
     return self;
 }
 
-/** @brief Initializes a key pair from a secret key*/
-- (nullable instancetype)initWithSecretKey:(NSData* _Nonnull)secretKey withError:(NSError *_Nullable*_Nullable)errorPtr {
+- (nullable instancetype)initWithSecretKey:(NSData* _Nonnull)secretKey
+                                 withError:(NSError *_Nullable*_Nullable)errorPtr {
     [self keyPairFromSecretKey: secretKey withError:errorPtr];
     return self;
 }
 
-- (void) generateKeyPair:(NSData* _Nullable)seed withError:(NSError *_Nullable*_Nullable)errorPtr {
+- (void) generateKeyPair:(NSData* _Nullable)seed
+               withError:(NSError *_Nullable*_Nullable)errorPtr {
+    
     //TODO deal with seed being null
     bbs_signature_byte_buffer_t seedBuffer;
     seedBuffer.len = seed.length;
@@ -56,7 +56,9 @@
     free(err);
 }
 
-- (void) keyPairFromSecretKey:(NSData* _Nonnull)secretKey withError:(NSError *_Nullable*_Nullable)errorPtr {
+- (void) keyPairFromSecretKey:(NSData* _Nonnull)secretKey
+                    withError:(NSError *_Nullable*_Nullable)errorPtr {
+    
     bbs_signature_byte_buffer_t secretKeyBuffer;
     secretKeyBuffer.len = secretKey.length;
     secretKeyBuffer.data = (uint8_t *)secretKey.bytes;

--- a/wrappers/obj-c/bbs-signatures/bls12381g2_key_pair.m
+++ b/wrappers/obj-c/bbs-signatures/bls12381g2_key_pair.m
@@ -15,8 +15,9 @@
 /** @brief Implementation of a BLS 12-381 G2 Key pair */
 @implementation Bls12381G2KeyPair
 
-- (nullable instancetype)initFromPublicKey:(NSData* _Nonnull)data {
-    self.publicKey = data;
+/** @brief Initializes a key pair from a public key*/
+- (nullable instancetype)initWithPublicKey:(NSData* _Nonnull)publicKey {
+    self.publicKey = [[NSData alloc] initWithData:publicKey];
     return self;
 }
 
@@ -29,12 +30,6 @@
 /** @brief Initializes a key pair from a secret key*/
 - (nullable instancetype)initWithSecretKey:(NSData* _Nonnull)secretKey withError:(NSError *_Nullable*_Nullable)errorPtr {
     [self keyPairFromSecretKey: secretKey withError:errorPtr];
-    return self;
-}
-
-/** @brief Initializes a key pair from a public key*/
-- (nullable instancetype)initWithPublicKey:(NSData* _Nonnull)publicKey {
-    self.publicKey = [[NSData alloc] initWithData:publicKey];
     return self;
 }
 

--- a/wrappers/obj-c/tests/Info.plist
+++ b/wrappers/obj-c/tests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/wrappers/obj-c/tests/bbs_key_pair.m
+++ b/wrappers/obj-c/tests/bbs_key_pair.m
@@ -14,7 +14,9 @@
     Bls12381G2KeyPair *keyPair = [[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error];
     NSUInteger *messageCount = 10;
     
-    BbsKeyPair *bbsKeyPair = [[BbsKeyPair alloc] initWithBls12381G2KeyPair:keyPair: messageCount withError:&error];
+    BbsKeyPair *bbsKeyPair = [[BbsKeyPair alloc] initWithBls12381G2KeyPair:keyPair
+                                                              messageCount:messageCount
+                                                                 withError:&error];
     
     XCTAssertEqual(bbsKeyPair.secretKey.length, 32);
     XCTAssertEqual(bbsKeyPair.messageCount, 10);
@@ -27,10 +29,12 @@
     Bls12381G2KeyPair *keyPair = [[Bls12381G2KeyPair alloc] initWithPublicKey:publicKey];
     NSUInteger *messageCount = 10;
     
-    //TODO
-    BbsKeyPair *bbsKeyPair = [[BbsKeyPair alloc] initWithBls12381G2KeyPair:keyPair :messageCount withError:&error];
+    BbsKeyPair *bbsKeyPair = [[BbsKeyPair alloc] initWithBls12381G2KeyPair:keyPair
+                                                              messageCount:messageCount
+                                                                 withError:&error];
     
     XCTAssertEqual(bbsKeyPair.secretKey, nil);
     XCTAssertEqual(bbsKeyPair.messageCount, 10);
+    XCTAssertEqual(bbsKeyPair.publicKey.length, 628);
 }
 @end

--- a/wrappers/obj-c/tests/bbs_key_pair.m
+++ b/wrappers/obj-c/tests/bbs_key_pair.m
@@ -1,5 +1,5 @@
 #import <XCTest/XCTest.h>
-#import "../bbs-signatures/bbs_signatures.h"
+#import "../bbs-signatures/bbs_key_pair.h"
 
 @interface BbsKeyPairTests : XCTestCase
 

--- a/wrappers/obj-c/tests/bbs_key_pair.m
+++ b/wrappers/obj-c/tests/bbs_key_pair.m
@@ -14,7 +14,7 @@
     Bls12381G2KeyPair *keyPair = [[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error];
     NSUInteger *messageCount = 10;
     
-    BbsKeyPair *bbsKeyPair = [[BbsKeyPair alloc] initFromBls12381G2KeyPair:keyPair:messageCount withError:&error];
+    BbsKeyPair *bbsKeyPair = [[BbsKeyPair alloc] initWithBls12381G2KeyPair:keyPair: messageCount withError:&error];
     
     XCTAssertEqual(bbsKeyPair.secretKey.length, 32);
     XCTAssertEqual(bbsKeyPair.messageCount, 10);
@@ -22,12 +22,13 @@
 
 - (void)testGeneratePublicKeyFromBls12381G2PublicKey {
     NSError *error = nil;
-    NSData *seed = [[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXcxr1fJyQRiNx1+ZekeQ+OU/AYV/lVxaPXXhFBIbxeIU8kIAAX68cwQ=" options:0];
+    NSData *publicKey = [[NSData alloc] initWithBase64EncodedString:@"qJgttTOthlZHltz+c0PE07hx3worb/cy7QY5iwRegQ9BfwvGahdqCO9Q9xuOnF5nD/Tq6t8zm9z26EAFCiaEJnL5b50D1cHDgNxBUPEEae+4bUb3JRsHaxBdZWDOo3pb" options:0];
     
-    Bls12381G2KeyPair *keyPair = [[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error];
+    Bls12381G2KeyPair *keyPair = [[Bls12381G2KeyPair alloc] initWithPublicKey:publicKey];
     NSUInteger *messageCount = 10;
     
-    BbsKeyPair *bbsKeyPair = [[BbsKeyPair alloc] initFromBls12381G2PublicKey:keyPair.publicKey :messageCount withError:&error];
+    //TODO
+    BbsKeyPair *bbsKeyPair = [[BbsKeyPair alloc] initWithBls12381G2KeyPair:keyPair :messageCount withError:&error];
     
     XCTAssertEqual(bbsKeyPair.secretKey, nil);
     XCTAssertEqual(bbsKeyPair.messageCount, 10);

--- a/wrappers/obj-c/tests/bbs_key_pair.m
+++ b/wrappers/obj-c/tests/bbs_key_pair.m
@@ -1,0 +1,35 @@
+#import <XCTest/XCTest.h>
+#import "../bbs-signatures/bbs_signatures.h"
+
+@interface BbsKeyPairTests : XCTestCase
+
+@end
+
+@implementation BbsKeyPairTests
+
+- (void)testGenerateKeyPairFromBls12381G2KeyPair {
+    NSError *error = nil;
+    NSData *seed = [[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXcxr1fJyQRiNx1+ZekeQ+OU/AYV/lVxaPXXhFBIbxeIU8kIAAX68cwQ=" options:0];
+    
+    Bls12381G2KeyPair *keyPair = [[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error];
+    NSUInteger *messageCount = 10;
+    
+    BbsKeyPair *bbsKeyPair = [[BbsKeyPair alloc] initFromBls12381G2KeyPair:keyPair:messageCount withError:&error];
+    
+    XCTAssertEqual(bbsKeyPair.secretKey.length, 32);
+    XCTAssertEqual(bbsKeyPair.messageCount, 10);
+}
+
+- (void)testGeneratePublicKeyFromBls12381G2PublicKey {
+    NSError *error = nil;
+    NSData *seed = [[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXcxr1fJyQRiNx1+ZekeQ+OU/AYV/lVxaPXXhFBIbxeIU8kIAAX68cwQ=" options:0];
+    
+    Bls12381G2KeyPair *keyPair = [[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error];
+    NSUInteger *messageCount = 10;
+    
+    BbsKeyPair *bbsKeyPair = [[BbsKeyPair alloc] initFromBls12381G2PublicKey:keyPair.publicKey :messageCount withError:&error];
+    
+    XCTAssertEqual(bbsKeyPair.secretKey, nil);
+    XCTAssertEqual(bbsKeyPair.messageCount, 10);
+}
+@end

--- a/wrappers/obj-c/tests/bbs_signature.m
+++ b/wrappers/obj-c/tests/bbs_signature.m
@@ -11,83 +11,124 @@
 - (void)testSignSingleMessage {
     NSError *error = nil;
     NSData *seed = [[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXcxr1fJyQRiNx1+ZekeQ+OU/AYV/lVxaPXXhFBIbxeIU8kIAAX68cwQ=" options:0];
-    BbsKeyPair *bbsKeyPair = [[BbsKeyPair alloc] initWithBls12381G2KeyPair:[[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error]:1 withError:&error];
+    BbsKeyPair *bbsKeyPair = [[BbsKeyPair alloc] initWithBls12381G2KeyPair:[[Bls12381G2KeyPair alloc] initWithSeed:seed
+                                                                                                         withError:&error]
+                                                              messageCount:1
+                                                                 withError:&error];
     NSArray *messages = [NSArray arrayWithObjects:[[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXc==" options:0], nil];
     
-    BbsSignature *signature = [[BbsSignature alloc] sign:bbsKeyPair:messages withError:&error];
+    BbsSignature *signature = [[BbsSignature alloc] sign:bbsKeyPair
+                                                messages:messages
+                                               withError:&error];
+    
     XCTAssertEqual(signature.value.length, 112);
 }
 
 - (void)testSignMultipleMessages {
     NSError *error = nil;
     NSData *seed = [[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXcxr1fJyQRiNx1+ZekeQ+OU/AYV/lVxaPXXhFBIbxeIU8kIAAX68cwQ=" options:0];
-    BbsKeyPair *bbsKeyPair = [[BbsKeyPair alloc] initWithBls12381G2KeyPair:[[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error]:3 withError:&error];
+    BbsKeyPair *bbsKeyPair = [[BbsKeyPair alloc] initWithBls12381G2KeyPair:[[Bls12381G2KeyPair alloc] initWithSeed:seed
+                                                                                                         withError:&error]
+                                                              messageCount:3
+                                                                 withError:&error];
     
     NSArray *messages = [NSArray arrayWithObjects:[[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXc==" options:0],
                                                   [[NSData alloc] initWithBase64EncodedString:@"xaPXXhFBIbxeIU==" options:0],
                                                   [[NSData alloc] initWithBase64EncodedString:@"BapXXhfBIbxeIU==" options:0], nil];
     
-    BbsSignature *signature = [[BbsSignature alloc] sign:bbsKeyPair:messages withError:&error];
+    BbsSignature *signature = [[BbsSignature alloc] sign:bbsKeyPair
+                                                messages:messages
+                                               withError:&error];
+    
     XCTAssertEqual(signature.value.length, 112);
 }
 
 - (void)testSignMultipleMessagesWhenPublicKeySupportsMore {
     NSError *error = nil;
     NSData *seed = [[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXcxr1fJyQRiNx1+ZekeQ+OU/AYV/lVxaPXXhFBIbxeIU8kIAAX68cwQ=" options:0];
-    BbsKeyPair *bbsKeyPair = [[BbsKeyPair alloc] initWithBls12381G2KeyPair:[[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error]:5 withError:&error];
+    BbsKeyPair *bbsKeyPair = [[BbsKeyPair alloc] initWithBls12381G2KeyPair:[[Bls12381G2KeyPair alloc] initWithSeed:seed
+                                                                                                         withError:&error]
+                                                              messageCount:5
+                                                                 withError:&error];
     
     NSArray *messages = [NSArray arrayWithObjects:[[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXc==" options:0],
                                                   [[NSData alloc] initWithBase64EncodedString:@"xaPXXhFBIbxeIU==" options:0],
                                                   [[NSData alloc] initWithBase64EncodedString:@"BapXXhfBIbxeIU==" options:0], nil];
     
-    BbsSignature *signature = [[BbsSignature alloc] sign:bbsKeyPair:messages withError:&error];
+    BbsSignature *signature = [[BbsSignature alloc] sign:bbsKeyPair
+                                                messages:messages
+                                               withError:&error];
+    
     XCTAssertEqual(signature.value.length, 112);
 }
 
 - (void)testThrowErrorWhenSigningTooManyMessages {
     NSError *error = nil;
     NSData *seed = [[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXcxr1fJyQRiNx1+ZekeQ+OU/AYV/lVxaPXXhFBIbxeIU8kIAAX68cwQ=" options:0];
-    BbsKeyPair *bbsKeyPair = [[BbsKeyPair alloc] initWithBls12381G2KeyPair:[[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error]:1 withError:&error];
+    BbsKeyPair *bbsKeyPair = [[BbsKeyPair alloc] initWithBls12381G2KeyPair:[[Bls12381G2KeyPair alloc] initWithSeed:seed
+                                                                                                         withError:&error]
+                                                              messageCount:1
+                                                                 withError:&error];
     
     NSArray *messages = [NSArray arrayWithObjects:[[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXc==" options:0],
                                                   [[NSData alloc] initWithBase64EncodedString:@"xaPXXhFBIbxeIU==" options:0],
                                                   [[NSData alloc] initWithBase64EncodedString:@"BapXXhfBIbxeIU==" options:0], nil];
 
-    [[BbsSignature alloc] sign:bbsKeyPair:messages withError:&error];
+    [[BbsSignature alloc] sign:bbsKeyPair
+                      messages:messages
+                     withError:&error];
+    
     XCTAssertNotNil(error);
 }
 
 - (void)testBlsSignSingleMessage {
     NSError *error = nil;
     NSData *seed = [[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXcxr1fJyQRiNx1+ZekeQ+OU/AYV/lVxaPXXhFBIbxeIU8kIAAX68cwQ=" options:0];
-    Bls12381G2KeyPair *keyPair = [[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error];
+    Bls12381G2KeyPair *keyPair = [[Bls12381G2KeyPair alloc] initWithSeed:seed
+                                                               withError:&error];
     NSArray *messages = [NSArray arrayWithObjects:[[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXc==" options:0], nil];
     
-    BbsSignature *signature = [[BbsSignature alloc] blsSign:keyPair:messages withError:&error];
+    BbsSignature *signature = [[BbsSignature alloc] blsSign:keyPair
+                                                   messages:messages
+                                                  withError:&error];
+    
     XCTAssertEqual(signature.value.length, 112);
 }
 
 - (void)testBlsSignMultipleMessages {
     NSError *error = nil;
     NSData *seed = [[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXcxr1fJyQRiNx1+ZekeQ+OU/AYV/lVxaPXXhFBIbxeIU8kIAAX68cwQ=" options:0];
-    Bls12381G2KeyPair *keyPair = [[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error];
+    Bls12381G2KeyPair *keyPair = [[Bls12381G2KeyPair alloc] initWithSeed:seed
+                                                               withError:&error];
     
     NSArray *messages = [NSArray arrayWithObjects:[[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXc==" options:0],
                                                   [[NSData alloc] initWithBase64EncodedString:@"xaPXXhFBIbxeIU==" options:0],
                                                   [[NSData alloc] initWithBase64EncodedString:@"BapXXhfBIbxeIU==" options:0], nil];
     
-    BbsSignature *signature = [[BbsSignature alloc] blsSign:keyPair:messages withError:&error];
+    BbsSignature *signature = [[BbsSignature alloc] blsSign:keyPair
+                                                   messages:messages
+                                                  withError:&error];
+    
     XCTAssertEqual(signature.value.length, 112);
 }
 
 - (void)testSignAndVerifySingleMessage {
     NSError *error = nil;
     NSData *seed = [[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXcxr1fJyQRiNx1+ZekeQ+OU/AYV/lVxaPXXhFBIbxeIU8kIAAX68cwQ=" options:0];
-    BbsKeyPair *bbsKeyPair = [[BbsKeyPair alloc] initWithBls12381G2KeyPair:[[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error]:1 withError:&error];
+    BbsKeyPair *bbsKeyPair = [[BbsKeyPair alloc] initWithBls12381G2KeyPair:[[Bls12381G2KeyPair alloc] initWithSeed:seed
+                                                                                                         withError:&error]
+                                                              messageCount:1
+                                                                 withError:&error];
     NSArray *messages = [NSArray arrayWithObjects:[[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXc==" options:0], nil];
     
-    BbsSignature *signature = [[BbsSignature alloc] sign:bbsKeyPair:messages withError:&error];
-    bool isVerified = [signature verify:bbsKeyPair :messages withError:&error];
+    BbsSignature *signature = [[BbsSignature alloc] sign:bbsKeyPair
+                                                messages:messages
+                                               withError:&error];
+    
+    bool isVerified = [signature verify:bbsKeyPair
+                               messages:messages
+                              withError:&error];
+    
     XCTAssertEqual(signature.value.length, 112);
     XCTAssertTrue(isVerified);
 }
@@ -95,14 +136,23 @@
 - (void)testSignAndVerifyMultipleMessages {
     NSError *error = nil;
     NSData *seed = [[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXcxr1fJyQRiNx1+ZekeQ+OU/AYV/lVxaPXXhFBIbxeIU8kIAAX68cwQ=" options:0];
-    BbsKeyPair *bbsKeyPair = [[BbsKeyPair alloc] initWithBls12381G2KeyPair:[[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error]:3 withError:&error];
+    BbsKeyPair *bbsKeyPair = [[BbsKeyPair alloc] initWithBls12381G2KeyPair:[[Bls12381G2KeyPair alloc] initWithSeed:seed
+                                                                                                         withError:&error]
+                                                              messageCount:3
+                                                                 withError:&error];
     
     NSArray *messages = [NSArray arrayWithObjects:[[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXc==" options:0],
                                                   [[NSData alloc] initWithBase64EncodedString:@"xaPXXhFBIbxeIU==" options:0],
                                                   [[NSData alloc] initWithBase64EncodedString:@"BapXXhfBIbxeIU==" options:0], nil];
     
-    BbsSignature *signature = [[BbsSignature alloc] sign:bbsKeyPair:messages withError:&error];
-    bool isVerified = [signature verify:bbsKeyPair :messages withError:&error];
+    BbsSignature *signature = [[BbsSignature alloc] sign:bbsKeyPair
+                                                messages:messages
+                                               withError:&error];
+    
+    bool isVerified = [signature verify:bbsKeyPair
+                               messages:messages
+                              withError:&error];
+    
     XCTAssertEqual(signature.value.length, 112);
     XCTAssertTrue(isVerified);
 }
@@ -111,12 +161,20 @@
     NSError *error = nil;
     NSData *seed = [[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXcxr1fJyQRiNx1+ZekeQ+OU/AYV/lVxaPXXhFBIbxeIU8kIAAX68cwQ=" options:0];
     NSData *signatureBuffer = [[NSData alloc] initWithBase64EncodedString:@"kTV8dar9xLWQZ5EzaWYqTRmgA6dw6wcrUw5c///crRD2QQPXX9Di+lgCPCXAA5D8Pytuh6bNSx6k4NZTR9KfSNdaejKl2zTU9poRfzZ2SIskdgSHTZ2y7jLm/UEGKsAs3tticBVj1Pm2GNhQI/OlXQ==" options:0];
-    BbsKeyPair *bbsKeyPair = [[BbsKeyPair alloc] initWithBls12381G2KeyPair:[[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error]:1 withError:&error];
+    BbsKeyPair *bbsKeyPair = [[BbsKeyPair alloc] initWithBls12381G2KeyPair:[[Bls12381G2KeyPair alloc] initWithSeed:seed
+                                                                                                         withError:&error]
+                                                              messageCount:1
+                                                                 withError:&error];
     
     NSArray *messages = [NSArray arrayWithObjects:[[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXc==" options:0], nil];
     
-    BbsSignature *signature = [[BbsSignature alloc] initWithBytes:signatureBuffer withError:&error];
-    bool isVerified = [signature verify:bbsKeyPair :messages withError:&error];
+    BbsSignature *signature = [[BbsSignature alloc] initWithBytes:signatureBuffer
+                                                        withError:&error];
+    
+    bool isVerified = [signature verify:bbsKeyPair
+                               messages:messages
+                              withError:&error];
+    
     XCTAssertEqual(signature.value.length, 112);
     XCTAssertFalse(isVerified);
 }
@@ -125,14 +183,21 @@
     NSError *error = nil;
     NSData *seed = [[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXcxr1fJyQRiNx1+ZekeQ+OU/AYV/lVxaPXXhFBIbxeIU8kIAAX68cwQ=" options:0];
     NSData *signatureBuffer = [[NSData alloc] initWithBase64EncodedString:@"jYidhsdqxvAyNXMV4/vNfGM/4AULfSyfvQiwh+dDd4JtnT5xHnwpzMYdLdHzBYwXaGE1k6ln/pwtI4RwQZpl03SCv/mT/3AdK8PB2y43MGdMSeGTyZGfZf+rUrEDEs3lTfmPK54E+JBzd96gnrF2iQ==" options:0];
-    BbsKeyPair *bbsKeyPair = [[BbsKeyPair alloc] initWithBls12381G2KeyPair:[[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error]:3 withError:&error];
+    BbsKeyPair *bbsKeyPair = [[BbsKeyPair alloc] initWithBls12381G2KeyPair:[[Bls12381G2KeyPair alloc] initWithSeed:seed                                                                                                                       withError:&error]
+                                                              messageCount:3
+                                                                 withError:&error];
     
     NSArray *messages = [NSArray arrayWithObjects:[[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXc==" options:0],
                                                   [[NSData alloc] initWithBase64EncodedString:@"xaPXXhFBIbxeIU==" options:0],
                                                   [[NSData alloc] initWithBase64EncodedString:@"BapXXhfBIbxeIU==" options:0], nil];
     
-    BbsSignature *signature = [[BbsSignature alloc] initWithBytes:signatureBuffer withError:&error];
-    bool isVerified = [signature verify:bbsKeyPair :messages withError:&error];
+    BbsSignature *signature = [[BbsSignature alloc] initWithBytes:signatureBuffer
+                                                        withError:&error];
+    
+    bool isVerified = [signature verify:bbsKeyPair
+                               messages:messages
+                              withError:&error];
+    
     XCTAssertEqual(signature.value.length, 112);
     XCTAssertFalse(isVerified);
 }
@@ -141,12 +206,20 @@
     NSError *error = nil;
     NSData *seed = [[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXcxr1fJyQRiNx1+ZekeQ+OU/AYV/lVxaPXXhFBIbxeIU8kIAAX68cwQ=" options:0];
     NSData *signatureBuffer = [[NSData alloc] initWithBase64EncodedString:@"jYidhsdqxvAyNXMV4/vNfGM/4AULfSyfvQiwh+dDd4JtnT5xHnwpzMYdLdHzBYwXaGE1k6ln/pwtI4RwQZpl03SCv/mT/3AdK8PB2y43MGdMSeGTyZGfZf+rUrEDEs3lTfmPK54E+JBzd96gnrF2iQ==" options:0];
-    BbsKeyPair *bbsKeyPair = [[BbsKeyPair alloc] initWithBls12381G2KeyPair:[[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error]:3 withError:&error];
+    BbsKeyPair *bbsKeyPair = [[BbsKeyPair alloc] initWithBls12381G2KeyPair:[[Bls12381G2KeyPair alloc] initWithSeed:seed
+                                                                                                         withError:&error]
+                                                              messageCount:3
+                                                                 withError:&error];
     
     NSArray *messages = [NSArray array];
     
-    BbsSignature *signature = [[BbsSignature alloc] initWithBytes:signatureBuffer withError:&error];
-    bool isVerified = [signature verify:bbsKeyPair :messages withError:&error];
+    BbsSignature *signature = [[BbsSignature alloc] initWithBytes:signatureBuffer
+                                                        withError:&error];
+    
+    bool isVerified = [signature verify:bbsKeyPair
+                               messages:messages
+                              withError:&error];
+    
     XCTAssertEqual(signature.value.length, 112);
     XCTAssertFalse(isVerified);
 }
@@ -154,11 +227,20 @@
 - (void)testBlsSignAndVerifySingleMessage {
     NSError *error = nil;
     NSData *seed = [[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXcxr1fJyQRiNx1+ZekeQ+OU/AYV/lVxaPXXhFBIbxeIU8kIAAX68cwQ=" options:0];
-    Bls12381G2KeyPair *keyPair = [[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error];
+    
+    Bls12381G2KeyPair *keyPair = [[Bls12381G2KeyPair alloc] initWithSeed:seed
+                                                               withError:&error];
+    
     NSArray *messages = [NSArray arrayWithObjects:[[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXc==" options:0], nil];
     
-    BbsSignature *signature = [[BbsSignature alloc] blsSign:keyPair:messages withError:&error];
-    bool isVerified = [signature blsVerify:keyPair :messages withError:&error];
+    BbsSignature *signature = [[BbsSignature alloc] blsSign:keyPair
+                                                   messages:messages
+                                                  withError:&error];
+    
+    bool isVerified = [signature blsVerify:keyPair
+                                  messages:messages
+                                 withError:&error];
+    
     XCTAssertEqual(signature.value.length, 112);
     XCTAssertTrue(isVerified);
 }
@@ -166,14 +248,21 @@
 - (void)testBlsSignAndVerifyMultipleMessages {
     NSError *error = nil;
     NSData *seed = [[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXcxr1fJyQRiNx1+ZekeQ+OU/AYV/lVxaPXXhFBIbxeIU8kIAAX68cwQ=" options:0];
-    Bls12381G2KeyPair *keyPair = [[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error];
+    Bls12381G2KeyPair *keyPair = [[Bls12381G2KeyPair alloc] initWithSeed:seed
+                                                               withError:&error];
     
     NSArray *messages = [NSArray arrayWithObjects:[[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXc==" options:0],
                                                   [[NSData alloc] initWithBase64EncodedString:@"xaPXXhFBIbxeIU==" options:0],
                                                   [[NSData alloc] initWithBase64EncodedString:@"BapXXhfBIbxeIU==" options:0], nil];
     
-    BbsSignature *signature = [[BbsSignature alloc] blsSign:keyPair:messages withError:&error];
-    bool isVerified = [signature blsVerify:keyPair :messages withError:&error];
+    BbsSignature *signature = [[BbsSignature alloc] blsSign:keyPair
+                                                   messages:messages
+                                                  withError:&error];
+    
+    bool isVerified = [signature blsVerify:keyPair
+                                  messages:messages
+                                 withError:&error];
+    
     XCTAssertEqual(signature.value.length, 112);
     XCTAssertTrue(isVerified);
 }
@@ -182,12 +271,19 @@
     NSError *error = nil;
     NSData *seed = [[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXcxr1fJyQRiNx1+ZekeQ+OU/AYV/lVxaPXXhFBIbxeIU8kIAAX68cwQ=" options:0];
     NSData *signatureBuffer = [[NSData alloc] initWithBase64EncodedString:@"kTV8dar9xLWQZ5EzaWYqTRmgA6dw6wcrUw5c///crRD2QQPXX9Di+lgCPCXAA5D8Pytuh6bNSx6k4NZTR9KfSNdaejKl2zTU9poRfzZ2SIskdgSHTZ2y7jLm/UEGKsAs3tticBVj1Pm2GNhQI/OlXQ==" options:0];
-    Bls12381G2KeyPair *keyPair = [[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error];
+    
+    Bls12381G2KeyPair *keyPair = [[Bls12381G2KeyPair alloc] initWithSeed:seed
+                                                               withError:&error];
     
     NSArray *messages = [NSArray arrayWithObjects:[[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXc==" options:0], nil];
     
-    BbsSignature *signature = [[BbsSignature alloc] initWithBytes:signatureBuffer withError:&error];
-    bool isVerified = [signature blsVerify:keyPair :messages withError:&error];
+    BbsSignature *signature = [[BbsSignature alloc] initWithBytes:signatureBuffer
+                                                        withError:&error];
+    
+    bool isVerified = [signature blsVerify:keyPair
+                                  messages:messages
+                                 withError:&error];
+    
     XCTAssertEqual(signature.value.length, 112);
     XCTAssertFalse(isVerified);
 }
@@ -196,14 +292,21 @@
     NSError *error = nil;
     NSData *seed = [[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXcxr1fJyQRiNx1+ZekeQ+OU/AYV/lVxaPXXhFBIbxeIU8kIAAX68cwQ=" options:0];
     NSData *signatureBuffer = [[NSData alloc] initWithBase64EncodedString:@"jYidhsdqxvAyNXMV4/vNfGM/4AULfSyfvQiwh+dDd4JtnT5xHnwpzMYdLdHzBYwXaGE1k6ln/pwtI4RwQZpl03SCv/mT/3AdK8PB2y43MGdMSeGTyZGfZf+rUrEDEs3lTfmPK54E+JBzd96gnrF2iQ==" options:0];
-    Bls12381G2KeyPair *keyPair = [[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error];
+    
+    Bls12381G2KeyPair *keyPair = [[Bls12381G2KeyPair alloc] initWithSeed:seed
+                                                               withError:&error];
     
     NSArray *messages = [NSArray arrayWithObjects:[[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXc==" options:0],
                                                   [[NSData alloc] initWithBase64EncodedString:@"xaPXXhFBIbxeIU==" options:0],
                                                   [[NSData alloc] initWithBase64EncodedString:@"BapXXhfBIbxeIU==" options:0], nil];
     
-    BbsSignature *signature = [[BbsSignature alloc] initWithBytes:signatureBuffer withError:&error];
-    bool isVerified = [signature blsVerify:keyPair :messages withError:&error];
+    BbsSignature *signature = [[BbsSignature alloc] initWithBytes:signatureBuffer
+                                                        withError:&error];
+    
+    bool isVerified = [signature blsVerify:keyPair
+                                  messages:messages
+                                 withError:&error];
+    
     XCTAssertEqual(signature.value.length, 112);
     XCTAssertFalse(isVerified);
 }
@@ -212,12 +315,19 @@
     NSError *error = nil;
     NSData *seed = [[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXcxr1fJyQRiNx1+ZekeQ+OU/AYV/lVxaPXXhFBIbxeIU8kIAAX68cwQ=" options:0];
     NSData *signatureBuffer = [[NSData data] initWithBase64EncodedString:@"jYidhsdqxvAyNXMV4/vNfGM/4AULfSyfvQiwh+dDd4JtnT5xHnwpzMYdLdHzBYwXaGE1k6ln/pwtI4RwQZpl03SCv/mT/3AdK8PB2y43MGdMSeGTyZGfZf+rUrEDEs3lTfmPK54E+JBzd96gnrF2iQ==" options:0];
-    Bls12381G2KeyPair *keyPair = [[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error];
+    
+    Bls12381G2KeyPair *keyPair = [[Bls12381G2KeyPair alloc] initWithSeed:seed
+                                                               withError:&error];
     
     NSArray *messages = [NSArray array];
     
-    BbsSignature *signature = [[BbsSignature alloc] initWithBytes:signatureBuffer withError:&error];
-    bool isVerified = [signature blsVerify:keyPair :messages withError:&error];
+    BbsSignature *signature = [[BbsSignature alloc] initWithBytes:signatureBuffer
+                                                        withError:&error];
+    
+    bool isVerified = [signature blsVerify:keyPair
+                                  messages:messages
+                                 withError:&error];
+    
     XCTAssertEqual(signature.value.length, 112);
     XCTAssertFalse(isVerified);
 }

--- a/wrappers/obj-c/tests/bbs_signature.m
+++ b/wrappers/obj-c/tests/bbs_signature.m
@@ -1,0 +1,224 @@
+#import <XCTest/XCTest.h>
+#import "../bbs-signatures/bbs_signatures.h"
+#import "../bbs-signatures/bbs.h"
+
+@interface BbsSignatureTests : XCTestCase
+
+@end
+
+@implementation BbsSignatureTests
+
+- (void)testSignSingleMessage {
+    NSError *error = nil;
+    NSData *seed = [[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXcxr1fJyQRiNx1+ZekeQ+OU/AYV/lVxaPXXhFBIbxeIU8kIAAX68cwQ=" options:0];
+    BbsKeyPair *bbsKeyPair = [[BbsKeyPair alloc] initFromBls12381G2KeyPair:[[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error]:1 withError:&error];
+    NSArray *messages = [NSArray arrayWithObjects:[[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXc==" options:0], nil];
+    
+    BbsSignature *signature = [[BbsSignature alloc] sign:bbsKeyPair:messages withError:&error];
+    XCTAssertEqual(signature.value.length, 112);
+}
+
+- (void)testSignMultipleMessages {
+    NSError *error = nil;
+    NSData *seed = [[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXcxr1fJyQRiNx1+ZekeQ+OU/AYV/lVxaPXXhFBIbxeIU8kIAAX68cwQ=" options:0];
+    BbsKeyPair *bbsKeyPair = [[BbsKeyPair alloc] initFromBls12381G2KeyPair:[[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error]:3 withError:&error];
+    
+    NSArray *messages = [NSArray arrayWithObjects:[[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXc==" options:0],
+                                                  [[NSData alloc] initWithBase64EncodedString:@"xaPXXhFBIbxeIU==" options:0],
+                                                  [[NSData alloc] initWithBase64EncodedString:@"BapXXhfBIbxeIU==" options:0], nil];
+    
+    BbsSignature *signature = [[BbsSignature alloc] sign:bbsKeyPair:messages withError:&error];
+    XCTAssertEqual(signature.value.length, 112);
+}
+
+- (void)testSignMultipleMessagesWhenPublicKeySupportsMore {
+    NSError *error = nil;
+    NSData *seed = [[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXcxr1fJyQRiNx1+ZekeQ+OU/AYV/lVxaPXXhFBIbxeIU8kIAAX68cwQ=" options:0];
+    BbsKeyPair *bbsKeyPair = [[BbsKeyPair alloc] initFromBls12381G2KeyPair:[[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error]:5 withError:&error];
+    
+    NSArray *messages = [NSArray arrayWithObjects:[[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXc==" options:0],
+                                                  [[NSData alloc] initWithBase64EncodedString:@"xaPXXhFBIbxeIU==" options:0],
+                                                  [[NSData alloc] initWithBase64EncodedString:@"BapXXhfBIbxeIU==" options:0], nil];
+    
+    BbsSignature *signature = [[BbsSignature alloc] sign:bbsKeyPair:messages withError:&error];
+    XCTAssertEqual(signature.value.length, 112);
+}
+
+- (void)testThrowErrorWhenSigningTooManyMessages {
+    NSError *error = nil;
+    NSData *seed = [[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXcxr1fJyQRiNx1+ZekeQ+OU/AYV/lVxaPXXhFBIbxeIU8kIAAX68cwQ=" options:0];
+    BbsKeyPair *bbsKeyPair = [[BbsKeyPair alloc] initFromBls12381G2KeyPair:[[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error]:1 withError:&error];
+    
+    NSArray *messages = [NSArray arrayWithObjects:[[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXc==" options:0],
+                                                  [[NSData alloc] initWithBase64EncodedString:@"xaPXXhFBIbxeIU==" options:0],
+                                                  [[NSData alloc] initWithBase64EncodedString:@"BapXXhfBIbxeIU==" options:0], nil];
+
+    [[BbsSignature alloc] sign:bbsKeyPair:messages withError:&error];
+    XCTAssertNotNil(error);
+}
+
+- (void)testBlsSignSingleMessage {
+    NSError *error = nil;
+    NSData *seed = [[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXcxr1fJyQRiNx1+ZekeQ+OU/AYV/lVxaPXXhFBIbxeIU8kIAAX68cwQ=" options:0];
+    Bls12381G2KeyPair *keyPair = [[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error];
+    NSArray *messages = [NSArray arrayWithObjects:[[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXc==" options:0], nil];
+    
+    BbsSignature *signature = [[BbsSignature alloc] blsSign:keyPair:messages withError:&error];
+    XCTAssertEqual(signature.value.length, 112);
+}
+
+- (void)testBlsSignMultipleMessages {
+    NSError *error = nil;
+    NSData *seed = [[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXcxr1fJyQRiNx1+ZekeQ+OU/AYV/lVxaPXXhFBIbxeIU8kIAAX68cwQ=" options:0];
+    Bls12381G2KeyPair *keyPair = [[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error];
+    
+    NSArray *messages = [NSArray arrayWithObjects:[[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXc==" options:0],
+                                                  [[NSData alloc] initWithBase64EncodedString:@"xaPXXhFBIbxeIU==" options:0],
+                                                  [[NSData alloc] initWithBase64EncodedString:@"BapXXhfBIbxeIU==" options:0], nil];
+    
+    BbsSignature *signature = [[BbsSignature alloc] blsSign:keyPair:messages withError:&error];
+    XCTAssertEqual(signature.value.length, 112);
+}
+
+- (void)testSignAndVerifySingleMessage {
+    NSError *error = nil;
+    NSData *seed = [[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXcxr1fJyQRiNx1+ZekeQ+OU/AYV/lVxaPXXhFBIbxeIU8kIAAX68cwQ=" options:0];
+    BbsKeyPair *bbsKeyPair = [[BbsKeyPair alloc] initFromBls12381G2KeyPair:[[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error]:1 withError:&error];
+    NSArray *messages = [NSArray arrayWithObjects:[[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXc==" options:0], nil];
+    
+    BbsSignature *signature = [[BbsSignature alloc] sign:bbsKeyPair:messages withError:&error];
+    bool isVerified = [signature verify:bbsKeyPair :messages withError:&error];
+    XCTAssertEqual(signature.value.length, 112);
+    XCTAssertTrue(isVerified);
+}
+
+- (void)testSignAndVerifyMultipleMessages {
+    NSError *error = nil;
+    NSData *seed = [[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXcxr1fJyQRiNx1+ZekeQ+OU/AYV/lVxaPXXhFBIbxeIU8kIAAX68cwQ=" options:0];
+    BbsKeyPair *bbsKeyPair = [[BbsKeyPair alloc] initFromBls12381G2KeyPair:[[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error]:3 withError:&error];
+    
+    NSArray *messages = [NSArray arrayWithObjects:[[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXc==" options:0],
+                                                  [[NSData alloc] initWithBase64EncodedString:@"xaPXXhFBIbxeIU==" options:0],
+                                                  [[NSData alloc] initWithBase64EncodedString:@"BapXXhfBIbxeIU==" options:0], nil];
+    
+    BbsSignature *signature = [[BbsSignature alloc] sign:bbsKeyPair:messages withError:&error];
+    bool isVerified = [signature verify:bbsKeyPair :messages withError:&error];
+    XCTAssertEqual(signature.value.length, 112);
+    XCTAssertTrue(isVerified);
+}
+
+- (void)testSignThrowErrorWithWrongSingleMessage {
+    NSError *error = nil;
+    NSData *seed = [[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXcxr1fJyQRiNx1+ZekeQ+OU/AYV/lVxaPXXhFBIbxeIU8kIAAX68cwQ=" options:0];
+    NSData *signatureBuffer = [[NSData alloc] initWithBase64EncodedString:@"kTV8dar9xLWQZ5EzaWYqTRmgA6dw6wcrUw5c///crRD2QQPXX9Di+lgCPCXAA5D8Pytuh6bNSx6k4NZTR9KfSNdaejKl2zTU9poRfzZ2SIskdgSHTZ2y7jLm/UEGKsAs3tticBVj1Pm2GNhQI/OlXQ==" options:0];
+    BbsKeyPair *bbsKeyPair = [[BbsKeyPair alloc] initFromBls12381G2KeyPair:[[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error]:1 withError:&error];
+    
+    NSArray *messages = [NSArray arrayWithObjects:[[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXc==" options:0], nil];
+    
+    BbsSignature *signature = [[BbsSignature alloc] initWithBytes:signatureBuffer withError:&error];
+    bool isVerified = [signature verify:bbsKeyPair :messages withError:&error];
+    XCTAssertEqual(signature.value.length, 112);
+    XCTAssertFalse(isVerified);
+}
+
+- (void)testSignThrowErrorWithWrongMessages {
+    NSError *error = nil;
+    NSData *seed = [[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXcxr1fJyQRiNx1+ZekeQ+OU/AYV/lVxaPXXhFBIbxeIU8kIAAX68cwQ=" options:0];
+    NSData *signatureBuffer = [[NSData alloc] initWithBase64EncodedString:@"jYidhsdqxvAyNXMV4/vNfGM/4AULfSyfvQiwh+dDd4JtnT5xHnwpzMYdLdHzBYwXaGE1k6ln/pwtI4RwQZpl03SCv/mT/3AdK8PB2y43MGdMSeGTyZGfZf+rUrEDEs3lTfmPK54E+JBzd96gnrF2iQ==" options:0];
+    BbsKeyPair *bbsKeyPair = [[BbsKeyPair alloc] initFromBls12381G2KeyPair:[[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error]:3 withError:&error];
+    
+    NSArray *messages = [NSArray arrayWithObjects:[[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXc==" options:0],
+                                                  [[NSData alloc] initWithBase64EncodedString:@"xaPXXhFBIbxeIU==" options:0],
+                                                  [[NSData alloc] initWithBase64EncodedString:@"BapXXhfBIbxeIU==" options:0], nil];
+    
+    BbsSignature *signature = [[BbsSignature alloc] initWithBytes:signatureBuffer withError:&error];
+    bool isVerified = [signature verify:bbsKeyPair :messages withError:&error];
+    XCTAssertEqual(signature.value.length, 112);
+    XCTAssertFalse(isVerified);
+}
+
+- (void)testSignThrowErrorWhenMessagesEmpty {
+    NSError *error = nil;
+    NSData *seed = [[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXcxr1fJyQRiNx1+ZekeQ+OU/AYV/lVxaPXXhFBIbxeIU8kIAAX68cwQ=" options:0];
+    NSData *signatureBuffer = [[NSData alloc] initWithBase64EncodedString:@"jYidhsdqxvAyNXMV4/vNfGM/4AULfSyfvQiwh+dDd4JtnT5xHnwpzMYdLdHzBYwXaGE1k6ln/pwtI4RwQZpl03SCv/mT/3AdK8PB2y43MGdMSeGTyZGfZf+rUrEDEs3lTfmPK54E+JBzd96gnrF2iQ==" options:0];
+    BbsKeyPair *bbsKeyPair = [[BbsKeyPair alloc] initFromBls12381G2KeyPair:[[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error]:3 withError:&error];
+    
+    NSArray *messages = [NSArray array];
+    
+    BbsSignature *signature = [[BbsSignature alloc] initWithBytes:signatureBuffer withError:&error];
+    bool isVerified = [signature verify:bbsKeyPair :messages withError:&error];
+    XCTAssertEqual(signature.value.length, 112);
+    XCTAssertFalse(isVerified);
+}
+
+- (void)testBlsSignAndVerifySingleMessage {
+    NSError *error = nil;
+    NSData *seed = [[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXcxr1fJyQRiNx1+ZekeQ+OU/AYV/lVxaPXXhFBIbxeIU8kIAAX68cwQ=" options:0];
+    Bls12381G2KeyPair *keyPair = [[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error];
+    NSArray *messages = [NSArray arrayWithObjects:[[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXc==" options:0], nil];
+    
+    BbsSignature *signature = [[BbsSignature alloc] blsSign:keyPair:messages withError:&error];
+    bool isVerified = [signature blsVerify:keyPair :messages withError:&error];
+    XCTAssertEqual(signature.value.length, 112);
+    XCTAssertTrue(isVerified);
+}
+
+- (void)testBlsSignAndVerifyMultipleMessages {
+    NSError *error = nil;
+    NSData *seed = [[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXcxr1fJyQRiNx1+ZekeQ+OU/AYV/lVxaPXXhFBIbxeIU8kIAAX68cwQ=" options:0];
+    Bls12381G2KeyPair *keyPair = [[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error];
+    
+    NSArray *messages = [NSArray arrayWithObjects:[[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXc==" options:0],
+                                                  [[NSData alloc] initWithBase64EncodedString:@"xaPXXhFBIbxeIU==" options:0],
+                                                  [[NSData alloc] initWithBase64EncodedString:@"BapXXhfBIbxeIU==" options:0], nil];
+    
+    BbsSignature *signature = [[BbsSignature alloc] blsSign:keyPair:messages withError:&error];
+    bool isVerified = [signature blsVerify:keyPair :messages withError:&error];
+    XCTAssertEqual(signature.value.length, 112);
+    XCTAssertTrue(isVerified);
+}
+
+- (void)testBlsVerifyThrowErrorWithWrongSingleMessage {
+    NSError *error = nil;
+    NSData *seed = [[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXcxr1fJyQRiNx1+ZekeQ+OU/AYV/lVxaPXXhFBIbxeIU8kIAAX68cwQ=" options:0];
+    NSData *signatureBuffer = [[NSData alloc] initWithBase64EncodedString:@"kTV8dar9xLWQZ5EzaWYqTRmgA6dw6wcrUw5c///crRD2QQPXX9Di+lgCPCXAA5D8Pytuh6bNSx6k4NZTR9KfSNdaejKl2zTU9poRfzZ2SIskdgSHTZ2y7jLm/UEGKsAs3tticBVj1Pm2GNhQI/OlXQ==" options:0];
+    Bls12381G2KeyPair *keyPair = [[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error];
+    
+    NSArray *messages = [NSArray arrayWithObjects:[[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXc==" options:0], nil];
+    
+    BbsSignature *signature = [[BbsSignature alloc] initWithBytes:signatureBuffer withError:&error];
+    bool isVerified = [signature blsVerify:keyPair :messages withError:&error];
+    XCTAssertEqual(signature.value.length, 112);
+    XCTAssertFalse(isVerified);
+}
+
+- (void)testBlsVerifyThrowErrorWithWrongMessages {
+    NSError *error = nil;
+    NSData *seed = [[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXcxr1fJyQRiNx1+ZekeQ+OU/AYV/lVxaPXXhFBIbxeIU8kIAAX68cwQ=" options:0];
+    NSData *signatureBuffer = [[NSData alloc] initWithBase64EncodedString:@"jYidhsdqxvAyNXMV4/vNfGM/4AULfSyfvQiwh+dDd4JtnT5xHnwpzMYdLdHzBYwXaGE1k6ln/pwtI4RwQZpl03SCv/mT/3AdK8PB2y43MGdMSeGTyZGfZf+rUrEDEs3lTfmPK54E+JBzd96gnrF2iQ==" options:0];
+    Bls12381G2KeyPair *keyPair = [[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error];
+    
+    NSArray *messages = [NSArray arrayWithObjects:[[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXc==" options:0],
+                                                  [[NSData alloc] initWithBase64EncodedString:@"xaPXXhFBIbxeIU==" options:0],
+                                                  [[NSData alloc] initWithBase64EncodedString:@"BapXXhfBIbxeIU==" options:0], nil];
+    
+    BbsSignature *signature = [[BbsSignature alloc] initWithBytes:signatureBuffer withError:&error];
+    bool isVerified = [signature blsVerify:keyPair :messages withError:&error];
+    XCTAssertEqual(signature.value.length, 112);
+    XCTAssertFalse(isVerified);
+}
+
+- (void)testBlsVerifyThrowErrorWhenMessagesEmpty {
+    NSError *error = nil;
+    NSData *seed = [[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXcxr1fJyQRiNx1+ZekeQ+OU/AYV/lVxaPXXhFBIbxeIU8kIAAX68cwQ=" options:0];
+    NSData *signatureBuffer = [[NSData data] initWithBase64EncodedString:@"jYidhsdqxvAyNXMV4/vNfGM/4AULfSyfvQiwh+dDd4JtnT5xHnwpzMYdLdHzBYwXaGE1k6ln/pwtI4RwQZpl03SCv/mT/3AdK8PB2y43MGdMSeGTyZGfZf+rUrEDEs3lTfmPK54E+JBzd96gnrF2iQ==" options:0];
+    Bls12381G2KeyPair *keyPair = [[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error];
+    
+    NSArray *messages = [NSArray array];
+    
+    BbsSignature *signature = [[BbsSignature alloc] initWithBytes:signatureBuffer withError:&error];
+    bool isVerified = [signature blsVerify:keyPair :messages withError:&error];
+    XCTAssertEqual(signature.value.length, 112);
+    XCTAssertFalse(isVerified);
+}
+@end

--- a/wrappers/obj-c/tests/bbs_signature.m
+++ b/wrappers/obj-c/tests/bbs_signature.m
@@ -11,7 +11,7 @@
 - (void)testSignSingleMessage {
     NSError *error = nil;
     NSData *seed = [[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXcxr1fJyQRiNx1+ZekeQ+OU/AYV/lVxaPXXhFBIbxeIU8kIAAX68cwQ=" options:0];
-    BbsKeyPair *bbsKeyPair = [[BbsKeyPair alloc] initFromBls12381G2KeyPair:[[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error]:1 withError:&error];
+    BbsKeyPair *bbsKeyPair = [[BbsKeyPair alloc] initWithBls12381G2KeyPair:[[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error]:1 withError:&error];
     NSArray *messages = [NSArray arrayWithObjects:[[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXc==" options:0], nil];
     
     BbsSignature *signature = [[BbsSignature alloc] sign:bbsKeyPair:messages withError:&error];
@@ -21,7 +21,7 @@
 - (void)testSignMultipleMessages {
     NSError *error = nil;
     NSData *seed = [[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXcxr1fJyQRiNx1+ZekeQ+OU/AYV/lVxaPXXhFBIbxeIU8kIAAX68cwQ=" options:0];
-    BbsKeyPair *bbsKeyPair = [[BbsKeyPair alloc] initFromBls12381G2KeyPair:[[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error]:3 withError:&error];
+    BbsKeyPair *bbsKeyPair = [[BbsKeyPair alloc] initWithBls12381G2KeyPair:[[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error]:3 withError:&error];
     
     NSArray *messages = [NSArray arrayWithObjects:[[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXc==" options:0],
                                                   [[NSData alloc] initWithBase64EncodedString:@"xaPXXhFBIbxeIU==" options:0],
@@ -34,7 +34,7 @@
 - (void)testSignMultipleMessagesWhenPublicKeySupportsMore {
     NSError *error = nil;
     NSData *seed = [[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXcxr1fJyQRiNx1+ZekeQ+OU/AYV/lVxaPXXhFBIbxeIU8kIAAX68cwQ=" options:0];
-    BbsKeyPair *bbsKeyPair = [[BbsKeyPair alloc] initFromBls12381G2KeyPair:[[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error]:5 withError:&error];
+    BbsKeyPair *bbsKeyPair = [[BbsKeyPair alloc] initWithBls12381G2KeyPair:[[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error]:5 withError:&error];
     
     NSArray *messages = [NSArray arrayWithObjects:[[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXc==" options:0],
                                                   [[NSData alloc] initWithBase64EncodedString:@"xaPXXhFBIbxeIU==" options:0],
@@ -47,7 +47,7 @@
 - (void)testThrowErrorWhenSigningTooManyMessages {
     NSError *error = nil;
     NSData *seed = [[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXcxr1fJyQRiNx1+ZekeQ+OU/AYV/lVxaPXXhFBIbxeIU8kIAAX68cwQ=" options:0];
-    BbsKeyPair *bbsKeyPair = [[BbsKeyPair alloc] initFromBls12381G2KeyPair:[[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error]:1 withError:&error];
+    BbsKeyPair *bbsKeyPair = [[BbsKeyPair alloc] initWithBls12381G2KeyPair:[[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error]:1 withError:&error];
     
     NSArray *messages = [NSArray arrayWithObjects:[[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXc==" options:0],
                                                   [[NSData alloc] initWithBase64EncodedString:@"xaPXXhFBIbxeIU==" options:0],
@@ -83,7 +83,7 @@
 - (void)testSignAndVerifySingleMessage {
     NSError *error = nil;
     NSData *seed = [[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXcxr1fJyQRiNx1+ZekeQ+OU/AYV/lVxaPXXhFBIbxeIU8kIAAX68cwQ=" options:0];
-    BbsKeyPair *bbsKeyPair = [[BbsKeyPair alloc] initFromBls12381G2KeyPair:[[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error]:1 withError:&error];
+    BbsKeyPair *bbsKeyPair = [[BbsKeyPair alloc] initWithBls12381G2KeyPair:[[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error]:1 withError:&error];
     NSArray *messages = [NSArray arrayWithObjects:[[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXc==" options:0], nil];
     
     BbsSignature *signature = [[BbsSignature alloc] sign:bbsKeyPair:messages withError:&error];
@@ -95,7 +95,7 @@
 - (void)testSignAndVerifyMultipleMessages {
     NSError *error = nil;
     NSData *seed = [[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXcxr1fJyQRiNx1+ZekeQ+OU/AYV/lVxaPXXhFBIbxeIU8kIAAX68cwQ=" options:0];
-    BbsKeyPair *bbsKeyPair = [[BbsKeyPair alloc] initFromBls12381G2KeyPair:[[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error]:3 withError:&error];
+    BbsKeyPair *bbsKeyPair = [[BbsKeyPair alloc] initWithBls12381G2KeyPair:[[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error]:3 withError:&error];
     
     NSArray *messages = [NSArray arrayWithObjects:[[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXc==" options:0],
                                                   [[NSData alloc] initWithBase64EncodedString:@"xaPXXhFBIbxeIU==" options:0],
@@ -111,7 +111,7 @@
     NSError *error = nil;
     NSData *seed = [[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXcxr1fJyQRiNx1+ZekeQ+OU/AYV/lVxaPXXhFBIbxeIU8kIAAX68cwQ=" options:0];
     NSData *signatureBuffer = [[NSData alloc] initWithBase64EncodedString:@"kTV8dar9xLWQZ5EzaWYqTRmgA6dw6wcrUw5c///crRD2QQPXX9Di+lgCPCXAA5D8Pytuh6bNSx6k4NZTR9KfSNdaejKl2zTU9poRfzZ2SIskdgSHTZ2y7jLm/UEGKsAs3tticBVj1Pm2GNhQI/OlXQ==" options:0];
-    BbsKeyPair *bbsKeyPair = [[BbsKeyPair alloc] initFromBls12381G2KeyPair:[[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error]:1 withError:&error];
+    BbsKeyPair *bbsKeyPair = [[BbsKeyPair alloc] initWithBls12381G2KeyPair:[[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error]:1 withError:&error];
     
     NSArray *messages = [NSArray arrayWithObjects:[[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXc==" options:0], nil];
     
@@ -125,7 +125,7 @@
     NSError *error = nil;
     NSData *seed = [[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXcxr1fJyQRiNx1+ZekeQ+OU/AYV/lVxaPXXhFBIbxeIU8kIAAX68cwQ=" options:0];
     NSData *signatureBuffer = [[NSData alloc] initWithBase64EncodedString:@"jYidhsdqxvAyNXMV4/vNfGM/4AULfSyfvQiwh+dDd4JtnT5xHnwpzMYdLdHzBYwXaGE1k6ln/pwtI4RwQZpl03SCv/mT/3AdK8PB2y43MGdMSeGTyZGfZf+rUrEDEs3lTfmPK54E+JBzd96gnrF2iQ==" options:0];
-    BbsKeyPair *bbsKeyPair = [[BbsKeyPair alloc] initFromBls12381G2KeyPair:[[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error]:3 withError:&error];
+    BbsKeyPair *bbsKeyPair = [[BbsKeyPair alloc] initWithBls12381G2KeyPair:[[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error]:3 withError:&error];
     
     NSArray *messages = [NSArray arrayWithObjects:[[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXc==" options:0],
                                                   [[NSData alloc] initWithBase64EncodedString:@"xaPXXhFBIbxeIU==" options:0],
@@ -141,7 +141,7 @@
     NSError *error = nil;
     NSData *seed = [[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXcxr1fJyQRiNx1+ZekeQ+OU/AYV/lVxaPXXhFBIbxeIU8kIAAX68cwQ=" options:0];
     NSData *signatureBuffer = [[NSData alloc] initWithBase64EncodedString:@"jYidhsdqxvAyNXMV4/vNfGM/4AULfSyfvQiwh+dDd4JtnT5xHnwpzMYdLdHzBYwXaGE1k6ln/pwtI4RwQZpl03SCv/mT/3AdK8PB2y43MGdMSeGTyZGfZf+rUrEDEs3lTfmPK54E+JBzd96gnrF2iQ==" options:0];
-    BbsKeyPair *bbsKeyPair = [[BbsKeyPair alloc] initFromBls12381G2KeyPair:[[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error]:3 withError:&error];
+    BbsKeyPair *bbsKeyPair = [[BbsKeyPair alloc] initWithBls12381G2KeyPair:[[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error]:3 withError:&error];
     
     NSArray *messages = [NSArray array];
     

--- a/wrappers/obj-c/tests/bbs_signature.m
+++ b/wrappers/obj-c/tests/bbs_signature.m
@@ -1,5 +1,7 @@
 #import <XCTest/XCTest.h>
-#import "../bbs-signatures/bbs_signatures.h"
+#import "../bbs-signatures/bbs_key_pair.h"
+#import "../bbs-signatures/bls12381g2_key_pair.h"
+#import "../bbs-signatures/bbs_signature.h"
 #import "../bbs-signatures/bbs.h"
 
 @interface BbsSignatureTests : XCTestCase

--- a/wrappers/obj-c/tests/bbs_signature_proof.m
+++ b/wrappers/obj-c/tests/bbs_signature_proof.m
@@ -15,7 +15,7 @@
     NSData *signatureData = [[NSData alloc] initWithBase64EncodedString:@"rpldJh9DkYe4FvX7WPYI+GNhBM7uB3UGg3NcJX+NTts9E5R9TtHSYszqVfLxdq0Mb45jyd82laouneFYjB5TreM5Qpo9TyO0yNPdaanmfW0wCeLp3r0bhdfOF67GGL01KHY56ojoaSWBmr2lpqRU2Q==" options:0];
     
     NSError *error = nil;
-    BbsKeyPair *keyPair = [[BbsKeyPair alloc] initFromPublicKey:publicKey :messages.count];
+    BbsKeyPair *keyPair = [[BbsKeyPair alloc] initWithData:publicKey :messages.count];
     BbsSignature *signature = [[BbsSignature alloc] initWithBytes:signatureData withError:&error];
     XCTAssertEqual(signature.value.length, 112);
     
@@ -35,7 +35,7 @@
     NSData *signatureData = [[NSData alloc] initWithBase64EncodedString:@"qg3PfohWGvbOCZWxcWIZ779aOuNSafjCXLdDux01TTNGm/Uqhr/kZZ1wSmxKwbEWAhctrDCp2mGE0M0l6DlA5R38chMbtnyWMfQgbQpzMQZgPBPUvVWivJyYEysZnQWrAYzZzRPe36VFbFy5ynWx0w==" options:0];
     
     NSError *error = nil;
-    BbsKeyPair *keyPair = [[BbsKeyPair alloc] initFromPublicKey:publicKey :messages.count];
+    BbsKeyPair *keyPair = [[BbsKeyPair alloc] initWithData:publicKey :messages.count];
     BbsSignature *signature = [[BbsSignature alloc] initWithBytes:signatureData withError:&error];
     XCTAssertEqual(signature.value.length, 112);
     
@@ -53,7 +53,7 @@
     NSData *signatureData = [[NSData alloc] initWithBase64EncodedString:@"qg3PfohWGvbOCZWxcWIZ779aOuNSafjCXLdDux01TTNGm/Uqhr/kZZ1wSmxKwbEWAhctrDCp2mGE0M0l6DlA5R38chMbtnyWMfQgbQpzMQZgPBPUvVWivJyYEysZnQWrAYzZzRPe36VFbFy5ynWx0w==" options:0];
     
     NSError *error = nil;
-    BbsKeyPair *keyPair = [[BbsKeyPair alloc] initFromPublicKey:publicKey :messages.count];
+    BbsKeyPair *keyPair = [[BbsKeyPair alloc] initWithData:publicKey :messages.count];
     BbsSignature *signature = [[BbsSignature alloc] initWithBytes:signatureData withError:&error];
     XCTAssertEqual(signature.value.length, 112);
     
@@ -71,7 +71,7 @@
     NSData *signatureData = [[NSData alloc] initWithBase64EncodedString:@"qg3PfohWGvbOCZWxcWIZ779aOuNSafjCXLdDux01TTNGm/Uqhr/kZZ1wSmxKwbEWAhctrDCp2mGE0M0l6DlA5R38chMbtnyWMfQgbQpzMQZgPBPUvVWivJyYEysZnQWrAYzZzRPe36VFbFy5ynWx0w==" options:0];
     
     NSError *error = nil;
-    BbsKeyPair *keyPair = [[BbsKeyPair alloc] initFromPublicKey:publicKey :messages.count];
+    BbsKeyPair *keyPair = [[BbsKeyPair alloc] initWithData:publicKey :messages.count];
     BbsSignature *signature = [[BbsSignature alloc] initWithBytes:signatureData withError:&error];
     XCTAssertEqual(signature.value.length, 112);
     
@@ -87,7 +87,7 @@
     NSData *signatureData = [[NSData alloc] initWithBase64EncodedString:@"r00WeXEj+07DUZb3JY6fbbKhHtQcxtLZsJUVU6liFZQKCLQYu77EXFZx4Vaa5VBtKpPK6tDGovHGgrgyizOm70VUZgzzBb0emvRIGSWhAKkcLL1z1HYwApnUE6XFFb96LUF4XM//QhEM774dX4ciqQ==" options:0];
     
     NSError *error = nil;
-    Bls12381G2KeyPair *keyPair = [[Bls12381G2KeyPair alloc] initFromPublicKey:publicKey];
+    Bls12381G2KeyPair *keyPair = [[Bls12381G2KeyPair alloc] initWithPublicKey:publicKey];
     BbsSignature *signature = [[BbsSignature alloc] initWithBytes:signatureData withError:&error];
     XCTAssertEqual(signature.value.length, 112);
     
@@ -107,7 +107,7 @@
     NSData *signatureData = [[NSData alloc] initWithBase64EncodedString:@"uISPYALbiNZwIgu1ndj9onUbkFA9trrhGFQJqJHFOSWCZYAIDUNTysXziar6+MdbPEiJS34OOlKAzxxnxIhFW0lBd4dbLOKf59LZPMRYc91tALAZeriyKcSVa7RzZl50UPjHfs31JrH6RgZ1V9/OVg==" options:0];
     
     NSError *error = nil;
-    Bls12381G2KeyPair *keyPair = [[Bls12381G2KeyPair alloc] initFromPublicKey:publicKey];
+    Bls12381G2KeyPair *keyPair = [[Bls12381G2KeyPair alloc] initWithPublicKey:publicKey];
     BbsSignature *signature = [[BbsSignature alloc] initWithBytes:signatureData withError:&error];
     XCTAssertEqual(signature.value.length, 112);
     
@@ -125,7 +125,7 @@
     NSData *signatureData = [[NSData alloc] initWithBase64EncodedString:@"uISPYALbiNZwIgu1ndj9onUbkFA9trrhGFQJqJHFOSWCZYAIDUNTysXziar6+MdbPEiJS34OOlKAzxxnxIhFW0lBd4dbLOKf59LZPMRYc91tALAZeriyKcSVa7RzZl50UPjHfs31JrH6RgZ1V9/OVg==" options:0];
     
     NSError *error = nil;
-    Bls12381G2KeyPair *keyPair = [[Bls12381G2KeyPair alloc] initFromPublicKey:publicKey];
+    Bls12381G2KeyPair *keyPair = [[Bls12381G2KeyPair alloc] initWithPublicKey:publicKey];
     BbsSignature *signature = [[BbsSignature alloc] initWithBytes:signatureData withError:&error];
     XCTAssertEqual(signature.value.length, 112);
     
@@ -144,7 +144,7 @@
     NSData *signatureData = [[NSData alloc] initWithBase64EncodedString:@"uISPYALbiNZwIgu1ndj9onUbkFA9trrhGFQJqJHFOSWCZYAIDUNTysXziar6+MdbPEiJS34OOlKAzxxnxIhFW0lBd4dbLOKf59LZPMRYc91tALAZeriyKcSVa7RzZl50UPjHfs31JrH6RgZ1V9/OVg==" options:0];
     
     NSError *error = nil;
-    Bls12381G2KeyPair *keyPair = [[Bls12381G2KeyPair alloc] initFromPublicKey:publicKey];
+    Bls12381G2KeyPair *keyPair = [[Bls12381G2KeyPair alloc] initWithPublicKey:publicKey];
     BbsSignature *signature = [[BbsSignature alloc] initWithBytes:signatureData withError:&error];
     XCTAssertEqual(signature.value.length, 112);
     

--- a/wrappers/obj-c/tests/bbs_signature_proof.m
+++ b/wrappers/obj-c/tests/bbs_signature_proof.m
@@ -1,0 +1,154 @@
+#import <XCTest/XCTest.h>
+#import "../bbs-signatures/bbs_signatures.h"
+
+@interface BbsSignatureProofTests : XCTestCase
+
+@end
+
+@implementation BbsSignatureProofTests
+
+- (void)testCreateProofRevealingSingleMessageFromSingleMessageSignature {
+    NSArray *revealed = [NSArray arrayWithObjects:[[NSNumber alloc] initWithInt:0], nil];
+    NSData *nonce = [[NSData alloc] initWithBase64EncodedString:@"MDEyMzQ1Njc4OQ==" options:0];
+    NSArray *messages = [NSArray arrayWithObjects:[[NSData alloc] initWithBase64EncodedString:@"Um10bkRCSkhzbzVpU2c9PQ==" options:0], nil];
+    NSData *publicKey = [[NSData alloc] initWithBase64EncodedString:@"qJgttTOthlZHltz+c0PE07hx3worb/cy7QY5iwRegQ9BfwvGahdqCO9Q9xuOnF5nD/Tq6t8zm9z26EAFCiaEJnL5b50D1cHDgNxBUPEEae+4bUb3JRsHaxBdZWDOo3pboZyjM38YgjaUBcjftZi5gb58Qz13XeRJpiuUHH06I7/1Eb8oVtIW5SGMNfKaqKhBAAAAAYPPztgxfWWw01/0SSug1oLfVuI4XUqhgyZ3rS6eTkOLjnyR3ObXb0XCD2Mfcxiv6w==" options:0];
+    NSData *signatureData = [[NSData alloc] initWithBase64EncodedString:@"rpldJh9DkYe4FvX7WPYI+GNhBM7uB3UGg3NcJX+NTts9E5R9TtHSYszqVfLxdq0Mb45jyd82laouneFYjB5TreM5Qpo9TyO0yNPdaanmfW0wCeLp3r0bhdfOF67GGL01KHY56ojoaSWBmr2lpqRU2Q==" options:0];
+    
+    NSError *error = nil;
+    BbsKeyPair *keyPair = [[BbsKeyPair alloc] initFromPublicKey:publicKey :messages.count];
+    BbsSignature *signature = [[BbsSignature alloc] initWithBytes:signatureData withError:&error];
+    XCTAssertEqual(signature.value.length, 112);
+    
+    BbsSignatureProof *proof = [[BbsSignatureProof alloc] createProof:signature :keyPair :nonce :messages :revealed withError:&error];
+    XCTAssertEqual(proof.value.length, 383);
+}
+
+- (void)testCreateProofRevealingAllMessagesFromMultiMessageSignature {
+    NSArray *revealed = [NSArray arrayWithObjects:[[NSNumber alloc] initWithInt:0],
+                                                  [[NSNumber alloc] initWithInt:1],
+                                                  [[NSNumber alloc] initWithInt:2], nil];
+    NSData *nonce = [[NSData alloc] initWithBase64EncodedString:@"MDEyMzQ1Njc4OQ==" options:0];
+    NSArray *messages = [NSArray arrayWithObjects:[[NSData alloc] initWithBase64EncodedString:@"SjQyQXhoY2lPVmtFOXc9PQ==" options:0],
+                                                  [[NSData alloc] initWithBase64EncodedString:@"UE5NbkFSV0lIUCtzMmc9PQ==" options:0],
+                                                  [[NSData alloc] initWithBase64EncodedString:@"dGk5V1loaEVlajg1anc9PQ==" options:0], nil];
+    NSData *publicKey = [[NSData alloc] initWithBase64EncodedString:@"qJgttTOthlZHltz+c0PE07hx3worb/cy7QY5iwRegQ9BfwvGahdqCO9Q9xuOnF5nD/Tq6t8zm9z26EAFCiaEJnL5b50D1cHDgNxBUPEEae+4bUb3JRsHaxBdZWDOo3pbiZ/pmArLDr3oSCqthKgSZw4VFzzJMFEuHP9AAnOnUJmqkOmvI1ctGLO6kCLFuwQVAAAAA4GrOHdyZEbTWRrTwIdz+KXWcEUHdIx41XSr/RK0TE5+qU7irAhQekOGFpGWQY4rYrDxoHToB4DblaJWUgkSZQLQ5sOfJg3qUJr9MpnDNJ8nNNitL65e6mqnpfsbbT3k94LBQI3/HijeRl29y5dGcLhOxldMtx2SvQg//kWOJ/Ug8e1aVo3V07XkR1Ltx76uzA==" options:0];
+    NSData *signatureData = [[NSData alloc] initWithBase64EncodedString:@"qg3PfohWGvbOCZWxcWIZ779aOuNSafjCXLdDux01TTNGm/Uqhr/kZZ1wSmxKwbEWAhctrDCp2mGE0M0l6DlA5R38chMbtnyWMfQgbQpzMQZgPBPUvVWivJyYEysZnQWrAYzZzRPe36VFbFy5ynWx0w==" options:0];
+    
+    NSError *error = nil;
+    BbsKeyPair *keyPair = [[BbsKeyPair alloc] initFromPublicKey:publicKey :messages.count];
+    BbsSignature *signature = [[BbsSignature alloc] initWithBytes:signatureData withError:&error];
+    XCTAssertEqual(signature.value.length, 112);
+    
+    BbsSignatureProof *proof = [[BbsSignatureProof alloc] createProof:signature :keyPair :nonce :messages :revealed withError:&error];
+    XCTAssertEqual(proof.value.length, 383);
+}
+
+- (void)testCreateProofRevealingSingleMessageFromMultiMessageSignature {
+    NSArray *revealed = [NSArray arrayWithObjects:[[NSNumber alloc] initWithInt:0], nil];
+    NSData *nonce = [[NSData alloc] initWithBase64EncodedString:@"MDEyMzQ1Njc4OQ==" options:0];
+    NSArray *messages = [NSArray arrayWithObjects:[[NSData alloc] initWithBase64EncodedString:@"SjQyQXhoY2lPVmtFOXc9PQ==" options:0],
+                                                  [[NSData alloc] initWithBase64EncodedString:@"UE5NbkFSV0lIUCtzMmc9PQ==" options:0],
+                                                  [[NSData alloc] initWithBase64EncodedString:@"dGk5V1loaEVlajg1anc9PQ==" options:0], nil];
+    NSData *publicKey = [[NSData alloc] initWithBase64EncodedString:@"qJgttTOthlZHltz+c0PE07hx3worb/cy7QY5iwRegQ9BfwvGahdqCO9Q9xuOnF5nD/Tq6t8zm9z26EAFCiaEJnL5b50D1cHDgNxBUPEEae+4bUb3JRsHaxBdZWDOo3pbiZ/pmArLDr3oSCqthKgSZw4VFzzJMFEuHP9AAnOnUJmqkOmvI1ctGLO6kCLFuwQVAAAAA4GrOHdyZEbTWRrTwIdz+KXWcEUHdIx41XSr/RK0TE5+qU7irAhQekOGFpGWQY4rYrDxoHToB4DblaJWUgkSZQLQ5sOfJg3qUJr9MpnDNJ8nNNitL65e6mqnpfsbbT3k94LBQI3/HijeRl29y5dGcLhOxldMtx2SvQg//kWOJ/Ug8e1aVo3V07XkR1Ltx76uzA==" options:0];
+    NSData *signatureData = [[NSData alloc] initWithBase64EncodedString:@"qg3PfohWGvbOCZWxcWIZ779aOuNSafjCXLdDux01TTNGm/Uqhr/kZZ1wSmxKwbEWAhctrDCp2mGE0M0l6DlA5R38chMbtnyWMfQgbQpzMQZgPBPUvVWivJyYEysZnQWrAYzZzRPe36VFbFy5ynWx0w==" options:0];
+    
+    NSError *error = nil;
+    BbsKeyPair *keyPair = [[BbsKeyPair alloc] initFromPublicKey:publicKey :messages.count];
+    BbsSignature *signature = [[BbsSignature alloc] initWithBytes:signatureData withError:&error];
+    XCTAssertEqual(signature.value.length, 112);
+    
+    BbsSignatureProof *proof = [[BbsSignatureProof alloc] createProof:signature :keyPair :nonce :messages :revealed withError:&error];
+    XCTAssertEqual(proof.value.length, 447);
+}
+
+- (void)testCreateProofRevealingMultipleMessagesFromMultiMessageSignature {
+    //TODO ADJUST REVEAL
+    NSData *nonce = [[NSData alloc] initWithBase64EncodedString:@"MDEyMzQ1Njc4OQ==" options:0];
+    NSArray *messages = [NSArray arrayWithObjects:[[NSData alloc] initWithBase64EncodedString:@"SjQyQXhoY2lPVmtFOXc9PQ==" options:0],
+                                                  [[NSData alloc] initWithBase64EncodedString:@"UE5NbkFSV0lIUCtzMmc9PQ==" options:0],
+                                                  [[NSData alloc] initWithBase64EncodedString:@"dGk5V1loaEVlajg1anc9PQ==" options:0], nil];
+    NSData *publicKey = [[NSData alloc] initWithBase64EncodedString:@"qJgttTOthlZHltz+c0PE07hx3worb/cy7QY5iwRegQ9BfwvGahdqCO9Q9xuOnF5nD/Tq6t8zm9z26EAFCiaEJnL5b50D1cHDgNxBUPEEae+4bUb3JRsHaxBdZWDOo3pbiZ/pmArLDr3oSCqthKgSZw4VFzzJMFEuHP9AAnOnUJmqkOmvI1ctGLO6kCLFuwQVAAAAA4GrOHdyZEbTWRrTwIdz+KXWcEUHdIx41XSr/RK0TE5+qU7irAhQekOGFpGWQY4rYrDxoHToB4DblaJWUgkSZQLQ5sOfJg3qUJr9MpnDNJ8nNNitL65e6mqnpfsbbT3k94LBQI3/HijeRl29y5dGcLhOxldMtx2SvQg//kWOJ/Ug8e1aVo3V07XkR1Ltx76uzA==" options:0];
+    NSData *signatureData = [[NSData alloc] initWithBase64EncodedString:@"qg3PfohWGvbOCZWxcWIZ779aOuNSafjCXLdDux01TTNGm/Uqhr/kZZ1wSmxKwbEWAhctrDCp2mGE0M0l6DlA5R38chMbtnyWMfQgbQpzMQZgPBPUvVWivJyYEysZnQWrAYzZzRPe36VFbFy5ynWx0w==" options:0];
+    
+    NSError *error = nil;
+    BbsKeyPair *keyPair = [[BbsKeyPair alloc] initFromPublicKey:publicKey :messages.count];
+    BbsSignature *signature = [[BbsSignature alloc] initWithBytes:signatureData withError:&error];
+    XCTAssertEqual(signature.value.length, 112);
+    
+    BbsSignatureProof *proof = [[BbsSignatureProof alloc] createProof:signature :keyPair :nonce :messages :messages withError:&error];
+    XCTAssertEqual(proof.value.length, 479);
+}
+
+- (void)testBlsCreateProofRevealingSingleMessageFromSingleMessageSignature {
+    NSArray *revealed = [NSArray arrayWithObjects:[[NSNumber alloc] initWithInt:0], nil];
+    NSData *nonce = [[NSData alloc] initWithBase64EncodedString:@"MDEyMzQ1Njc4OQ==" options:0];
+    NSArray *messages = [NSArray arrayWithObjects:[[NSData alloc] initWithBase64EncodedString:@"dXpBb1FGcUxnUmVpZHc9PQ==" options:0], nil];
+    NSData *publicKey = [[NSData alloc] initWithBase64EncodedString:@"qJgttTOthlZHltz+c0PE07hx3worb/cy7QY5iwRegQ9BfwvGahdqCO9Q9xuOnF5nD/Tq6t8zm9z26EAFCiaEJnL5b50D1cHDgNxBUPEEae+4bUb3JRsHaxBdZWDOo3pb" options:0];
+    NSData *signatureData = [[NSData alloc] initWithBase64EncodedString:@"r00WeXEj+07DUZb3JY6fbbKhHtQcxtLZsJUVU6liFZQKCLQYu77EXFZx4Vaa5VBtKpPK6tDGovHGgrgyizOm70VUZgzzBb0emvRIGSWhAKkcLL1z1HYwApnUE6XFFb96LUF4XM//QhEM774dX4ciqQ==" options:0];
+    
+    NSError *error = nil;
+    Bls12381G2KeyPair *keyPair = [[Bls12381G2KeyPair alloc] initFromPublicKey:publicKey];
+    BbsSignature *signature = [[BbsSignature alloc] initWithBytes:signatureData withError:&error];
+    XCTAssertEqual(signature.value.length, 112);
+    
+    BbsSignatureProof *proof = [[BbsSignatureProof alloc] blsCreateProof:signature :keyPair :nonce :messages :revealed withError:&error];
+    XCTAssertEqual(proof.value.length, 383);
+}
+
+- (void)testBlsCreateProofRevealingAllMessagesFromMultiMessageSignature {
+    NSArray *revealed = [NSArray arrayWithObjects:[[NSNumber alloc] initWithInt:0],
+                                                  [[NSNumber alloc] initWithInt:1],
+                                                  [[NSNumber alloc] initWithInt:2], nil];
+    NSData *nonce = [[NSData alloc] initWithBase64EncodedString:@"MDEyMzQ1Njc4OQ==" options:0];
+    NSArray *messages = [NSArray arrayWithObjects:[[NSData alloc] initWithBase64EncodedString:@"QytuMXJQejEvdFZ6UGc9PQ==" options:0],
+                                                  [[NSData alloc] initWithBase64EncodedString:@"aDN4OGNieVNxQzRyTEE9PQ==" options:0],
+                                                  [[NSData alloc] initWithBase64EncodedString:@"TUdmNzRvZkdkUndOYnc9PQ==" options:0], nil];
+    NSData *publicKey = [[NSData alloc] initWithBase64EncodedString:@"qJgttTOthlZHltz+c0PE07hx3worb/cy7QY5iwRegQ9BfwvGahdqCO9Q9xuOnF5nD/Tq6t8zm9z26EAFCiaEJnL5b50D1cHDgNxBUPEEae+4bUb3JRsHaxBdZWDOo3pb" options:0];
+    NSData *signatureData = [[NSData alloc] initWithBase64EncodedString:@"uISPYALbiNZwIgu1ndj9onUbkFA9trrhGFQJqJHFOSWCZYAIDUNTysXziar6+MdbPEiJS34OOlKAzxxnxIhFW0lBd4dbLOKf59LZPMRYc91tALAZeriyKcSVa7RzZl50UPjHfs31JrH6RgZ1V9/OVg==" options:0];
+    
+    NSError *error = nil;
+    Bls12381G2KeyPair *keyPair = [[Bls12381G2KeyPair alloc] initFromPublicKey:publicKey];
+    BbsSignature *signature = [[BbsSignature alloc] initWithBytes:signatureData withError:&error];
+    XCTAssertEqual(signature.value.length, 112);
+    
+    BbsSignatureProof *proof = [[BbsSignatureProof alloc] blsCreateProof:signature :keyPair :nonce :messages :revealed withError:&error];
+    XCTAssertEqual(proof.value.length, 383);
+}
+
+- (void)testBlsCreateProofRevealingSingleMessageFromMultiMessageSignature {
+    NSArray *revealed = [NSArray arrayWithObjects:[[NSNumber alloc] initWithInt:0], nil];
+    NSData *nonce = [[NSData alloc] initWithBase64EncodedString:@"MDEyMzQ1Njc4OQ==" options:0];
+    NSArray *messages = [NSArray arrayWithObjects:[[NSData alloc] initWithBase64EncodedString:@"QytuMXJQejEvdFZ6UGc9PQ==" options:0],
+                                                  [[NSData alloc] initWithBase64EncodedString:@"aDN4OGNieVNxQzRyTEE9PQ==" options:0],
+                                                  [[NSData alloc] initWithBase64EncodedString:@"TUdmNzRvZkdkUndOYnc9PQ==" options:0], nil];
+    NSData *publicKey = [[NSData alloc] initWithBase64EncodedString:@"qJgttTOthlZHltz+c0PE07hx3worb/cy7QY5iwRegQ9BfwvGahdqCO9Q9xuOnF5nD/Tq6t8zm9z26EAFCiaEJnL5b50D1cHDgNxBUPEEae+4bUb3JRsHaxBdZWDOo3pb" options:0];
+    NSData *signatureData = [[NSData alloc] initWithBase64EncodedString:@"uISPYALbiNZwIgu1ndj9onUbkFA9trrhGFQJqJHFOSWCZYAIDUNTysXziar6+MdbPEiJS34OOlKAzxxnxIhFW0lBd4dbLOKf59LZPMRYc91tALAZeriyKcSVa7RzZl50UPjHfs31JrH6RgZ1V9/OVg==" options:0];
+    
+    NSError *error = nil;
+    Bls12381G2KeyPair *keyPair = [[Bls12381G2KeyPair alloc] initFromPublicKey:publicKey];
+    BbsSignature *signature = [[BbsSignature alloc] initWithBytes:signatureData withError:&error];
+    XCTAssertEqual(signature.value.length, 112);
+    
+    BbsSignatureProof *proof = [[BbsSignatureProof alloc] blsCreateProof:signature :keyPair :nonce :messages :revealed withError:&error];
+    XCTAssertEqual(proof.value.length, 447);
+}
+
+- (void)testBlsCreateProofRevealingMultipleMessagesFromMultiMessageSignature {
+    NSArray *revealed = [NSArray arrayWithObjects:[[NSNumber alloc] initWithInt:0],
+                                                  [[NSNumber alloc] initWithInt:2], nil];
+    NSData *nonce = [[NSData alloc] initWithBase64EncodedString:@"MDEyMzQ1Njc4OQ==" options:0];
+    NSArray *messages = [NSArray arrayWithObjects:[[NSData alloc] initWithBase64EncodedString:@"QytuMXJQejEvdFZ6UGc9PQ==" options:0],
+                                                  [[NSData alloc] initWithBase64EncodedString:@"aDN4OGNieVNxQzRyTEE9PQ==" options:0],
+                                                  [[NSData alloc] initWithBase64EncodedString:@"TUdmNzRvZkdkUndOYnc9PQ==" options:0], nil];
+    NSData *publicKey = [[NSData alloc] initWithBase64EncodedString:@"qJgttTOthlZHltz+c0PE07hx3worb/cy7QY5iwRegQ9BfwvGahdqCO9Q9xuOnF5nD/Tq6t8zm9z26EAFCiaEJnL5b50D1cHDgNxBUPEEae+4bUb3JRsHaxBdZWDOo3pb" options:0];
+    NSData *signatureData = [[NSData alloc] initWithBase64EncodedString:@"uISPYALbiNZwIgu1ndj9onUbkFA9trrhGFQJqJHFOSWCZYAIDUNTysXziar6+MdbPEiJS34OOlKAzxxnxIhFW0lBd4dbLOKf59LZPMRYc91tALAZeriyKcSVa7RzZl50UPjHfs31JrH6RgZ1V9/OVg==" options:0];
+    
+    NSError *error = nil;
+    Bls12381G2KeyPair *keyPair = [[Bls12381G2KeyPair alloc] initFromPublicKey:publicKey];
+    BbsSignature *signature = [[BbsSignature alloc] initWithBytes:signatureData withError:&error];
+    XCTAssertEqual(signature.value.length, 112);
+    
+    BbsSignatureProof *proof = [[BbsSignatureProof alloc] blsCreateProof:signature :keyPair :nonce :messages :revealed withError:&error];
+    XCTAssertEqual(proof.value.length, 415);
+}
+@end

--- a/wrappers/obj-c/tests/bbs_signature_proof.m
+++ b/wrappers/obj-c/tests/bbs_signature_proof.m
@@ -1,5 +1,8 @@
 #import <XCTest/XCTest.h>
-#import "../bbs-signatures/bbs_signatures.h"
+#import "../bbs-signatures/bbs_key_pair.h"
+#import "../bbs-signatures/bls12381g2_key_pair.h"
+#import "../bbs-signatures/bbs_signature.h"
+#import "../bbs-signatures/bbs_signature_proof.h"
 
 @interface BbsSignatureProofTests : XCTestCase
 

--- a/wrappers/obj-c/tests/bbs_signature_proof.m
+++ b/wrappers/obj-c/tests/bbs_signature_proof.m
@@ -15,11 +15,21 @@
     NSData *signatureData = [[NSData alloc] initWithBase64EncodedString:@"rpldJh9DkYe4FvX7WPYI+GNhBM7uB3UGg3NcJX+NTts9E5R9TtHSYszqVfLxdq0Mb45jyd82laouneFYjB5TreM5Qpo9TyO0yNPdaanmfW0wCeLp3r0bhdfOF67GGL01KHY56ojoaSWBmr2lpqRU2Q==" options:0];
     
     NSError *error = nil;
-    BbsKeyPair *keyPair = [[BbsKeyPair alloc] initWithData:publicKey :messages.count];
-    BbsSignature *signature = [[BbsSignature alloc] initWithBytes:signatureData withError:&error];
+    BbsKeyPair *keyPair = [[BbsKeyPair alloc] initWithData:publicKey
+                                              messageCount:messages.count];
+    
+    BbsSignature *signature = [[BbsSignature alloc] initWithBytes:signatureData
+                                                        withError:&error];
+    
     XCTAssertEqual(signature.value.length, 112);
     
-    BbsSignatureProof *proof = [[BbsSignatureProof alloc] createProof:signature :keyPair :nonce :messages :revealed withError:&error];
+    BbsSignatureProof *proof = [[BbsSignatureProof alloc] createProof:signature
+                                                              keyPair:keyPair
+                                                                nonce:nonce
+                                                             messages:messages
+                                                             revealed:revealed
+                                                            withError:&error];
+    
     XCTAssertEqual(proof.value.length, 383);
 }
 
@@ -35,11 +45,21 @@
     NSData *signatureData = [[NSData alloc] initWithBase64EncodedString:@"qg3PfohWGvbOCZWxcWIZ779aOuNSafjCXLdDux01TTNGm/Uqhr/kZZ1wSmxKwbEWAhctrDCp2mGE0M0l6DlA5R38chMbtnyWMfQgbQpzMQZgPBPUvVWivJyYEysZnQWrAYzZzRPe36VFbFy5ynWx0w==" options:0];
     
     NSError *error = nil;
-    BbsKeyPair *keyPair = [[BbsKeyPair alloc] initWithData:publicKey :messages.count];
-    BbsSignature *signature = [[BbsSignature alloc] initWithBytes:signatureData withError:&error];
+    BbsKeyPair *keyPair = [[BbsKeyPair alloc] initWithData:publicKey
+                                              messageCount:messages.count];
+    
+    BbsSignature *signature = [[BbsSignature alloc] initWithBytes:signatureData
+                                                        withError:&error];
+    
     XCTAssertEqual(signature.value.length, 112);
     
-    BbsSignatureProof *proof = [[BbsSignatureProof alloc] createProof:signature :keyPair :nonce :messages :revealed withError:&error];
+    BbsSignatureProof *proof = [[BbsSignatureProof alloc] createProof:signature
+                                                              keyPair:keyPair
+                                                                nonce:nonce
+                                                             messages:messages
+                                                             revealed:revealed
+                                                            withError:&error];
+    
     XCTAssertEqual(proof.value.length, 383);
 }
 
@@ -53,16 +73,27 @@
     NSData *signatureData = [[NSData alloc] initWithBase64EncodedString:@"qg3PfohWGvbOCZWxcWIZ779aOuNSafjCXLdDux01TTNGm/Uqhr/kZZ1wSmxKwbEWAhctrDCp2mGE0M0l6DlA5R38chMbtnyWMfQgbQpzMQZgPBPUvVWivJyYEysZnQWrAYzZzRPe36VFbFy5ynWx0w==" options:0];
     
     NSError *error = nil;
-    BbsKeyPair *keyPair = [[BbsKeyPair alloc] initWithData:publicKey :messages.count];
-    BbsSignature *signature = [[BbsSignature alloc] initWithBytes:signatureData withError:&error];
+    BbsKeyPair *keyPair = [[BbsKeyPair alloc] initWithData:publicKey
+                                              messageCount:messages.count];
+    
+    BbsSignature *signature = [[BbsSignature alloc] initWithBytes:signatureData
+                                                        withError:&error];
+    
     XCTAssertEqual(signature.value.length, 112);
     
-    BbsSignatureProof *proof = [[BbsSignatureProof alloc] createProof:signature :keyPair :nonce :messages :revealed withError:&error];
+    BbsSignatureProof *proof = [[BbsSignatureProof alloc] createProof:signature
+                                                              keyPair:keyPair
+                                                                nonce:nonce
+                                                             messages:messages
+                                                             revealed:revealed
+                                                            withError:&error];
+    
     XCTAssertEqual(proof.value.length, 447);
 }
 
 - (void)testCreateProofRevealingMultipleMessagesFromMultiMessageSignature {
-    //TODO ADJUST REVEAL
+    NSArray *revealed = [NSArray arrayWithObjects:[[NSNumber alloc] initWithInt:0],
+                                                  [[NSNumber alloc] initWithInt:2], nil];
     NSData *nonce = [[NSData alloc] initWithBase64EncodedString:@"MDEyMzQ1Njc4OQ==" options:0];
     NSArray *messages = [NSArray arrayWithObjects:[[NSData alloc] initWithBase64EncodedString:@"SjQyQXhoY2lPVmtFOXc9PQ==" options:0],
                                                   [[NSData alloc] initWithBase64EncodedString:@"UE5NbkFSV0lIUCtzMmc9PQ==" options:0],
@@ -71,12 +102,21 @@
     NSData *signatureData = [[NSData alloc] initWithBase64EncodedString:@"qg3PfohWGvbOCZWxcWIZ779aOuNSafjCXLdDux01TTNGm/Uqhr/kZZ1wSmxKwbEWAhctrDCp2mGE0M0l6DlA5R38chMbtnyWMfQgbQpzMQZgPBPUvVWivJyYEysZnQWrAYzZzRPe36VFbFy5ynWx0w==" options:0];
     
     NSError *error = nil;
-    BbsKeyPair *keyPair = [[BbsKeyPair alloc] initWithData:publicKey :messages.count];
-    BbsSignature *signature = [[BbsSignature alloc] initWithBytes:signatureData withError:&error];
+    BbsKeyPair *keyPair = [[BbsKeyPair alloc] initWithData:publicKey
+                                              messageCount:messages.count];
+    
+    BbsSignature *signature = [[BbsSignature alloc] initWithBytes:signatureData
+                                                        withError:&error];
+    
     XCTAssertEqual(signature.value.length, 112);
     
-    BbsSignatureProof *proof = [[BbsSignatureProof alloc] createProof:signature :keyPair :nonce :messages :messages withError:&error];
-    XCTAssertEqual(proof.value.length, 479);
+    BbsSignatureProof *proof = [[BbsSignatureProof alloc] createProof:signature
+                                                              keyPair:keyPair
+                                                                nonce:nonce
+                                                             messages:messages
+                                                             revealed:revealed
+                                                            withError:&error];
+    XCTAssertEqual(proof.value.length, 415);
 }
 
 - (void)testBlsCreateProofRevealingSingleMessageFromSingleMessageSignature {
@@ -88,10 +128,18 @@
     
     NSError *error = nil;
     Bls12381G2KeyPair *keyPair = [[Bls12381G2KeyPair alloc] initWithPublicKey:publicKey];
-    BbsSignature *signature = [[BbsSignature alloc] initWithBytes:signatureData withError:&error];
+    
+    BbsSignature *signature = [[BbsSignature alloc] initWithBytes:signatureData
+                                                        withError:&error];
+    
     XCTAssertEqual(signature.value.length, 112);
     
-    BbsSignatureProof *proof = [[BbsSignatureProof alloc] blsCreateProof:signature :keyPair :nonce :messages :revealed withError:&error];
+    BbsSignatureProof *proof = [[BbsSignatureProof alloc] blsCreateProof:signature
+                                                                 keyPair:keyPair
+                                                                   nonce:nonce
+                                                                messages:messages
+                                                                revealed:revealed
+                                                               withError:&error];
     XCTAssertEqual(proof.value.length, 383);
 }
 
@@ -111,7 +159,12 @@
     BbsSignature *signature = [[BbsSignature alloc] initWithBytes:signatureData withError:&error];
     XCTAssertEqual(signature.value.length, 112);
     
-    BbsSignatureProof *proof = [[BbsSignatureProof alloc] blsCreateProof:signature :keyPair :nonce :messages :revealed withError:&error];
+    BbsSignatureProof *proof = [[BbsSignatureProof alloc] blsCreateProof:signature
+                                                                 keyPair:keyPair
+                                                                   nonce:nonce
+                                                                messages:messages
+                                                                revealed:revealed
+                                                               withError:&error];
     XCTAssertEqual(proof.value.length, 383);
 }
 
@@ -129,7 +182,13 @@
     BbsSignature *signature = [[BbsSignature alloc] initWithBytes:signatureData withError:&error];
     XCTAssertEqual(signature.value.length, 112);
     
-    BbsSignatureProof *proof = [[BbsSignatureProof alloc] blsCreateProof:signature :keyPair :nonce :messages :revealed withError:&error];
+    BbsSignatureProof *proof = [[BbsSignatureProof alloc] blsCreateProof:signature
+                                                                 keyPair:keyPair
+                                                                   nonce:nonce
+                                                                messages:messages
+                                                                revealed:revealed
+                                                               withError:&error];
+    
     XCTAssertEqual(proof.value.length, 447);
 }
 
@@ -148,7 +207,13 @@
     BbsSignature *signature = [[BbsSignature alloc] initWithBytes:signatureData withError:&error];
     XCTAssertEqual(signature.value.length, 112);
     
-    BbsSignatureProof *proof = [[BbsSignatureProof alloc] blsCreateProof:signature :keyPair :nonce :messages :revealed withError:&error];
+    BbsSignatureProof *proof = [[BbsSignatureProof alloc] blsCreateProof:signature
+                                                                 keyPair:keyPair
+                                                                   nonce:nonce
+                                                                messages:messages
+                                                                revealed:revealed
+                                                               withError:&error];
+    
     XCTAssertEqual(proof.value.length, 415);
 }
 @end

--- a/wrappers/obj-c/tests/bls12381g2_key_pair.m
+++ b/wrappers/obj-c/tests/bls12381g2_key_pair.m
@@ -1,0 +1,41 @@
+#import <XCTest/XCTest.h>
+#import "../bbs-signatures/bbs_signatures.h"
+#import "../bbs-signatures/bbs.h"
+
+@interface Bls12381G2KeyPairTests : XCTestCase
+
+@end
+
+@implementation Bls12381G2KeyPairTests
+
+- (void)testGetPublicKeySize {
+    //TODO need to rename this to G2
+    XCTAssertEqual(bls_public_key_size(), 96);
+}
+
+- (void)testGetSecretKeySize {
+    XCTAssertEqual(bls_secret_key_size(), 32);
+}
+
+- (void)testGenerateKeyPairWithSeed {
+    NSError *error = nil;
+    NSData *expectedPublicKey = [[NSData alloc] initWithBase64EncodedString:@"qJgttTOthlZHltz+c0PE07hx3worb/cy7QY5iwRegQ9BfwvGahdqCO9Q9xuOnF5nD/Tq6t8zm9z26EAFCiaEJnL5b50D1cHDgNxBUPEEae+4bUb3JRsHaxBdZWDOo3pb" options:0];
+    NSData *expectedSecretKey = [[NSData alloc] initWithBase64EncodedString:@"YoASulEi3WV7yfJ+yWctJRCbHfr7WjK7JjcMrRqbL6E=" options:0];
+    NSData *seed = [[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXcxr1fJyQRiNx1+ZekeQ+OU/AYV/lVxaPXXhFBIbxeIU8kIAAX68cwQ=" options:0];
+    
+    Bls12381G2KeyPair *keyPair = [[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error];
+
+    XCTAssertEqualObjects(keyPair.publicKey, expectedPublicKey);
+    XCTAssertEqualObjects(keyPair.secretKey, expectedSecretKey);
+}
+
+- (void)testGenerateKeyPairWithoutSeed {
+    NSData *seed = NULL;
+    NSError *error = nil;
+    
+    Bls12381G2KeyPair *keyPair = [[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error];
+    
+    XCTAssertEqual(keyPair.publicKey.length, 96);
+    XCTAssertEqual(keyPair.secretKey.length, 32);
+}
+@end

--- a/wrappers/obj-c/tests/bls12381g2_key_pair.m
+++ b/wrappers/obj-c/tests/bls12381g2_key_pair.m
@@ -1,5 +1,6 @@
 #import <XCTest/XCTest.h>
-#import "../bbs-signatures/bbs_signatures.h"
+#import "../bbs-signatures/bbs_key_pair.h"
+#import "../bbs-signatures/bls12381g2_key_pair.h"
 #import "../bbs-signatures/bbs.h"
 
 @interface Bls12381G2KeyPairTests : XCTestCase

--- a/wrappers/obj-c/tests/bls12381g2_key_pair.m
+++ b/wrappers/obj-c/tests/bls12381g2_key_pair.m
@@ -23,7 +23,8 @@
     NSData *expectedSecretKey = [[NSData alloc] initWithBase64EncodedString:@"YoASulEi3WV7yfJ+yWctJRCbHfr7WjK7JjcMrRqbL6E=" options:0];
     NSData *seed = [[NSData alloc] initWithBase64EncodedString:@"H297BpoOgkfpXcxr1fJyQRiNx1+ZekeQ+OU/AYV/lVxaPXXhFBIbxeIU8kIAAX68cwQ=" options:0];
     
-    Bls12381G2KeyPair *keyPair = [[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error];
+    Bls12381G2KeyPair *keyPair = [[Bls12381G2KeyPair alloc] initWithSeed:seed
+                                                               withError:&error];
 
     XCTAssertEqualObjects(keyPair.publicKey, expectedPublicKey);
     XCTAssertEqualObjects(keyPair.secretKey, expectedSecretKey);
@@ -33,7 +34,8 @@
     NSData *seed = NULL;
     NSError *error = nil;
     
-    Bls12381G2KeyPair *keyPair = [[Bls12381G2KeyPair alloc] initWithSeed: seed withError:&error];
+    Bls12381G2KeyPair *keyPair = [[Bls12381G2KeyPair alloc] initWithSeed:seed
+                                                               withError:&error];
     
     XCTAssertEqual(keyPair.publicKey.length, 96);
     XCTAssertEqual(keyPair.secretKey.length, 32);


### PR DESCRIPTION
Adds in preliminary support for an objective-c wrapper for bbs-signatures.