### PR TITLE
fix: bbs crate reference to released version

### DIFF
--- a/.github/workflows/ci-obj-c.yml
+++ b/.github/workflows/ci-obj-c.yml
@@ -28,3 +28,5 @@ jobs:
 
       - name: Build and test wrapper
         run: yarn wrapper:obj-c:build
+        env:
+          DEVELOPER_DIR: /Applications/Xcode_11.7.app/Contents/Developer

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ debug = false
 
 [dependencies]
 arrayref = "0.3"
-bbs = { version = "0.4", git = "https://github.com/mikelodder7/ursa", branch = "master" }
+bbs = "0.4"
 ffi-support = "0.4"
 lazy_static = "1.4"
 serde = { version = "1.0", features = ["serde_derive"] }


### PR DESCRIPTION
Moves to using the released version of the BBS crate