### PR TITLE
fix(build): c test under ./tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "build:windows": "mkdir -p .\\out && .\\scripts\\build.sh WINDOWS .\\out",
     "build:linux": "mkdir -p ./out && ./scripts/build.sh LINUX ./out",
     "test": "make test",
+    "test:macos": "./scripts/test.sh C MACOS",
     "wrapper:obj-c:build": "pod lib lint --allow-warnings",
     "wrapper:obj-c:update-binary": "yarn build:ios && cp out/ios/universal/libbbs.a wrappers/obj-c/libraries/libbbs.a",
     "version": "conventional-changelog -p angular -i CHANGELOG.md -s && git add CHANGELOG.md",

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,45 @@
+# Test using the rust lib in other languages on different platforms.
+# Currently it only supports testing ffi-bbs-signatures in a C project on macos.
+
+set -e
+
+LANGUAGE=$1
+PLATFORM=$2
+
+if [ -z "$LANGUAGE" ]
+then
+  echo "ERROR: LANGUAGE argument must be supplied and must be one of the following: C, JAVA, PYTHON, DOTNET, OBJECT-C"
+  exit 1
+fi
+
+if [ -z "$PLATFORM" ]
+then
+  echo "ERROR: PLATFORM argument must be supplied and must be one of the following: WINDOWS, LINUX, MACOS, IOS, ANDROID"
+  exit 1
+fi
+
+case $PLATFORM in
+  MACOS)
+      echo "Building for Apple Darwin x86_64"
+      rustup target add x86_64-apple-darwin
+      case $LANGUAGE in
+        C)
+          echo "To be used with C"
+          cargo build --target x86_64-apple-darwin --release
+          export RUST_LIBRARY_DIRECTORY="${PWD}/target/x86_64-apple-darwin/release"
+          cd $RUST_LIBRARY_DIRECTORY
+          cmake ../../../tests
+          cmake --build .
+          ./bbs_test
+          ;;
+        *)
+          echo "ERROR: LANGUAGE not supported: $1"
+          exit 1
+          ;;
+      esac
+      ;;
+  *)
+    echo "ERROR: PLATFORM not supported: $2"
+    exit 1
+    ;;
+esac

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(bbs_test LANGUAGES C)
+
+add_executable(bbs_test bbs_test.c)
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY $ENV{RUST_LIBRARY_DIRECTORY})
+
+target_include_directories(bbs_test PUBLIC "../include")
+
+file(GLOB LIBRARIES "$ENV{RUST_LIBRARY_DIRECTORY}/*.dylib")
+
+target_link_libraries(bbs_test PUBLIC "${LIBRARIES}")

--- a/tests/bbs_test.c
+++ b/tests/bbs_test.c
@@ -51,7 +51,7 @@ int main(int argc, char** argv) {
     printf("Create key pair...");
     fflush(stdout);
 
-    if (bls_generate_key(*seed, d_public_key, secret_key, err) != 0) {
+    if (bls_generate_g2_key(*seed, d_public_key, secret_key, err) != 0) {
         printf("fail\n");
         goto Fail;
     }
@@ -59,9 +59,9 @@ int main(int argc, char** argv) {
 
     printf("Public key is correct size...");
     fflush(stdout);
-    if (d_public_key->len != bls_public_key_size()) {
+    if (d_public_key->len != bls_public_key_g2_size()) {
         printf("fail\n");
-        printf("    Expected %d, Found: %lld\n", bls_public_key_size(), d_public_key->len);
+        printf("    Expected %d, Found: %lld\n", bls_public_key_g2_size(), d_public_key->len);
         goto Exit;
     }
     printf("pass\n");


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above
-->

## Description

The c test under the tests folder was broken. With the interface changes there, it seems to be no bls_generate_key any more. Only bls_generate_key_g1 or bls_generate_key_g2. We can actually use **[cbindgen](https://github.com/eqrion/cbindgen)** later to make sure the header file under ./include remains relevant. I also added the cmake file and the script that is needed to build the test.  This PR is going to fix the build of the test for macos. However the test itself still fails with the following result which should be investigated separately:

> Create key pair...pass
> Public key is correct size...pass
> Secret key is correct size...pass
> Create BBS key from BLS key that can sign 5 messages...pass
> Create sign context...pass
> Set public key in sign context...pass
> Set secret key in sign context...pass
> Set messages sign context...pass
> Sign 5 messages ...pass
> Signature is correct size...pass
> Create blind commitment context...pass
> Set messages to commitment...pass
> Set public key in blind sign commitment...pass
> Set nonce in blind sign commitment...pass
> Get blind sign commitment...pass
> Create verify blind signing commitment...pass
> Add blinded index...pass
> Set public key in verify blind sign context...pass
> Set nonce in verify blind sign context...pass
> Set proof in verify blind sign context...pass
> Verify blind sign context...pass
> Create blind signing context...pass
> Set messages blind sign context...pass
> Set public key in blind sign context...pass
> Set secret key in blind sign context...pass
> Set commitment in blind sign context...pass
> Creating blind signature...pass
> Unblinding signature...pass
> Create new verify signature context...pass
> Set messages in verify signature context...pass
> Set public key in verify signature context...pass
> Set signature in verify signature context...pass
> Verifying signature...fail
> Error Message = (null)
> Tests Failed
> ✨  Done in 41.97s.
> 

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] Changes follow the **[contributing](../docs/contributing.md)** document.

## Motivation and Context

To fix and automate testing the library in a C project 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Which merge strategy will you use?

<!-- This indicates to reviewers whether they need to check your commits are ready to be rebased on master or not. -->

- [x] Squash
- [ ] Rebase (REVIEW COMMITS)
