### PR TITLE
ci(rust): add clippy check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
 
+      - name: Lint
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
       - name: Build
         run: yarn build
 

--- a/src/java.rs
+++ b/src/java.rs
@@ -916,7 +916,7 @@ pub extern "C" fn Java_bbs_signatures_Bbs_bbs_1create_1proof_1context_1add_1proo
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C" fn Java_bbs_signatures_Bbs_bbs_1create_1proof_1size(_: JNIEnv, _: JObject, handle: jlong) -> jint {
-    return bbs_create_proof_context_size(handle as u64)
+    bbs_create_proof_context_size(handle as u64)
 }
 
 #[allow(non_snake_case)]
@@ -1074,7 +1074,7 @@ fn get_secret_key(env: &JNIEnv, secret_key: jbyteArray) -> Result<SecretKey, jin
         Err(_) => Err(0),
         Ok(s) => {
             if s.len() != FR_COMPRESSED_SIZE {
-                return Err(0);
+                Err(0)
             } else {
                 Ok(SecretKey::from(array_ref![s, 0, FR_COMPRESSED_SIZE]))
             }


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above
-->

## Description

<!--- Describe your changes in detail -->
This PR adds a build step to run `clippy` (if we want to trigger only on `*.rs` file changes, we need a separate workflow).

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] Changes follow the **[contributing](../docs/contributing.md)** document.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it relates to an open issue, please link to the issue here.
e.g.
[#123](https://github.com/mattrglobal/ffi-bbs-signatures/issues/123)
-->

Closes https://github.com/mattrglobal/ffi-bbs-signatures/issues/9.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Which merge strategy will you use?

<!-- This indicates to reviewers whether they need to check your commits are ready to be rebased on master or not. -->

- [x] Squash
- [ ] Rebase (REVIEW COMMITS)
