### PR TITLE
Fix build problems

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,11 +1,11 @@
 [target.aarch64-linux-android]
-ar = ".NDK/arm64/bin/aarch64-linux-android-ar"
-linker = ".NDK/arm64/bin/aarch64-linux-android-clang"
+ar = ".NDK/toolchains/llvm/prebuilt/darwin-x86_64/bin/aarch64-linux-android-ar"
+linker = ".NDK/toolchains/llvm/prebuilt/darwin-x86_64/bin/aarch64-linux-android21-clang"
 
 [target.armv7-linux-androideabi]
-ar = ".NDK/arm/bin/arm-linux-androideabi-ar"
-linker = ".NDK/arm/bin/arm-linux-androideabi-clang"
+ar = ".NDK/llvm/prebuilt/darwin-x86_64/bin/arm-linux-androideabi-ar"
+linker = ".NDK/toolchains/llvm/prebuilt/darwin-x86_64/bin/armv7a-linux-androideabi21-clang"
 
 [target.i686-linux-android]
-ar = ".NDK/x86/bin/i686-linux-android-ar"
-linker = ".NDK/x86/bin/i686-linux-android-clang"
+ar = ".NDK/toolchains/llvm/prebuilt/darwin-x86_64/bin/i686-linux-android-ar"
+linker = ".NDK/toolchains/llvm/prebuilt/darwin-x86_64/bin/i686-linux-android21-clang"

--- a/.github/workflows/ci-dotnet.yml
+++ b/.github/workflows/ci-dotnet.yml
@@ -63,7 +63,13 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v1
+      - uses: nttld/setup-ndk@v1
+        id: setup-ndk
+        with:
+          ndk-version: r21e
       - run: yarn build:android
+        env:
+          ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
       - uses: actions/upload-artifact@v2
         with:
           name: android

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,16 @@ jobs:
       - name: Lint
         run: cargo clippy --all-targets --all-features -- -D warnings
 
+      - name: Set up Android NDK
+        uses: nttld/setup-ndk@v1
+        id: setup-ndk
+        with:
+          ndk-version: r21e
+
       - name: Build
         run: yarn build
+        env:
+          ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
 
       - name: Test
         run: yarn test:macos

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -83,12 +83,13 @@ case $PLATFORM in
         # TODO make this configurable in the environment
         ANDROID_API_LEVEL=21
 
-        mkdir -p .NDK
+        echo "Using NDK home: $ANDROID_NDK_HOME"
+
+        ln -s $ANDROID_NDK_HOME .NDK
         mkdir -p $OUTPUT_LOCATION/android
 
         # ARM build
         echo "Building for Android ARM"
-        "$ANDROID_NDK_HOME/build/tools/make_standalone_toolchain.py" --api $ANDROID_API_LEVEL --arch arm --install-dir .NDK/arm --force
         rustup target add armv7-linux-androideabi
         mkdir -p $OUTPUT_LOCATION/android/armeabi-v7a/
         cargo build --target armv7-linux-androideabi --release
@@ -96,7 +97,6 @@ case $PLATFORM in
 
         # ARM 64 build
         echo "Building for Android ARM 64"
-        "$ANDROID_NDK_HOME/build/tools/make_standalone_toolchain.py" --api $ANDROID_API_LEVEL --arch arm64 --install-dir .NDK/arm64 --force
         rustup target add aarch64-linux-android
         mkdir -p $OUTPUT_LOCATION/android/arm64-v8a/
         cargo build --target aarch64-linux-android --release
@@ -104,7 +104,6 @@ case $PLATFORM in
 
         # x86 build
         echo "Building for Android x86"
-        "$ANDROID_NDK_HOME/build/tools/make_standalone_toolchain.py" --api $ANDROID_API_LEVEL --arch x86 --install-dir .NDK/x86 --force;
         rustup target add i686-linux-android
         mkdir -p $OUTPUT_LOCATION/android/x86/
         cargo build --target i686-linux-android --release

--- a/src/bbs_blind_commitment.rs
+++ b/src/bbs_blind_commitment.rs
@@ -79,7 +79,7 @@ pub extern "C" fn bbs_blind_commitment_context_finish(
             }
 
             match (ctx.nonce.as_ref(), ctx.public_key.as_ref()) {
-                (Some(ref n), Some(ref pk)) => {
+                (Some(n), Some(pk)) => {
                     let (c, b) = Prover::new_blind_signature_context(pk, &ctx.messages, n)?;
                     let mut output = Vec::new();
                     output.append(&mut b.to_bytes_compressed_form().to_vec());

--- a/src/bbs_blind_sign.rs
+++ b/src/bbs_blind_sign.rs
@@ -88,7 +88,7 @@ pub extern "C" fn bbs_blind_sign_context_finish(
             let commitment = ctx.commitment.as_ref().unwrap();
             let sk = ctx.secret_key.as_ref().unwrap();
             let pk = ctx.public_key.as_ref().unwrap();
-            let sig = BlindSignature::new(&commitment, &ctx.messages, &sk, &pk)?;
+            let sig = BlindSignature::new(commitment, &ctx.messages, sk, pk)?;
             Ok(ByteBuffer::from_vec(
                 sig.to_bytes_compressed_form().to_vec(),
             ))

--- a/src/bbs_create_proof.rs
+++ b/src/bbs_create_proof.rs
@@ -109,7 +109,7 @@ pub extern "C" fn bbs_create_proof_context_finish(
             let public_key = &ctx.public_key.as_ref().unwrap();
             let nonce = &ctx.nonce.as_ref().unwrap();
 
-            let pok = PoKOfSignature::init(signature, public_key, &ctx.messages.as_slice())?;
+            let pok = PoKOfSignature::init(signature, public_key, ctx.messages.as_slice())?;
             let mut challenge_bytes = pok.to_bytes();
             challenge_bytes.extend_from_slice(&nonce.to_bytes_compressed_form()[..]);
             let challenge_hash = ProofChallenge::hash(&challenge_bytes);

--- a/src/bbs_sign.rs
+++ b/src/bbs_sign.rs
@@ -70,7 +70,7 @@ pub extern "C" fn bbs_sign_context_finish(
             }
 
             match (ctx.secret_key.as_ref(), ctx.public_key.as_ref()) {
-                (Some(ref sk), Some(ref pk)) => {
+                (Some(sk), Some(pk)) => {
                     let s = Signature::new(ctx.messages.as_slice(), sk, pk)?;
                     Ok(ByteBuffer::from_vec(s.to_bytes_compressed_form().to_vec()))
                 }
@@ -149,7 +149,7 @@ pub extern "C" fn bbs_verify_context_finish(handle: u64, err: &mut ExternError) 
         }
 
         match (ctx.signature.as_ref(), ctx.public_key.as_ref()) {
-            (Some(ref sig), Some(ref pk)) => match sig.verify(ctx.messages.as_slice(), pk) {
+            (Some(sig), Some(pk)) => match sig.verify(ctx.messages.as_slice(), pk) {
                 Ok(b) => Ok(if b { 0 } else { 1 }),
                 Err(e) => Err(BbsFfiError(format!("{:?}", e))),
             },

--- a/src/bbs_verify_proof.rs
+++ b/src/bbs_verify_proof.rs
@@ -76,7 +76,7 @@ impl Serialize for PoKOfSignatureProofWrapper {
     where
         S: Serializer,
     {
-        serializer.serialize_bytes(&self.to_bytes().as_slice())
+        serializer.serialize_bytes(self.to_bytes().as_slice())
     }
 }
 

--- a/src/java.rs
+++ b/src/java.rs
@@ -126,10 +126,9 @@ pub extern "C" fn Java_bbs_signatures_Bbs_bls_1generate_1g1_1key(
     public_key: jbyteArray,
     secret_key: jbyteArray,
 ) -> jint {
-    let ikm;
-    match env.convert_byte_array(seed) {
+    let ikm = match env.convert_byte_array(seed) {
         Err(_) => return 1,
-        Ok(s) => ikm = s,
+        Ok(s) => s,
     };
     let s = if ikm.is_empty() { None } else { Some(ikm) };
     let (pk_bytes, sk_bytes) = bls_generate_g1_key(s);
@@ -149,10 +148,9 @@ pub extern "C" fn Java_bbs_signatures_Bbs_bls_1generate_1g2_1key(
     public_key: jbyteArray,
     secret_key: jbyteArray,
 ) -> jint {
-    let ikm;
-    match env.convert_byte_array(seed) {
+    let ikm = match env.convert_byte_array(seed) {
         Err(_) => return 1,
-        Ok(s) => ikm = s,
+        Ok(s) => s,
     };
     let s = if ikm.is_empty() { None } else { Some(ikm) };
     let (pk_bytes, sk_bytes) = bls_generate_g2_key(s);
@@ -173,10 +171,9 @@ pub extern "C" fn Java_bbs_signatures_Bbs_bls_1generate_1blinded_1g1_1key(
     public_key: jbyteArray,
     secret_key: jbyteArray,
 ) -> jint {
-    let ikm;
-    match env.convert_byte_array(seed) {
+    let ikm =match env.convert_byte_array(seed) {
         Err(_) => return 1,
-        Ok(s) => ikm = s,
+        Ok(s) => s,
     };
     let s = if ikm.is_empty() { None } else { Some(ikm) };
     let (r_bytes, pk_bytes, sk_bytes) = bls_generate_blinded_g1_key(s);
@@ -199,10 +196,9 @@ pub extern "C" fn Java_bbs_signatures_Bbs_bls_1generate_1blinded_1g2_1key(
     public_key: jbyteArray,
     secret_key: jbyteArray,
 ) -> jint {
-    let ikm;
-    match env.convert_byte_array(seed) {
+    let ikm = match env.convert_byte_array(seed) {
         Err(_) => return 1,
-        Ok(s) => ikm = s,
+        Ok(s) => s,
     };
     let s = if ikm.is_empty() { None } else { Some(ikm) };
     let (r_bytes, pk_bytes, sk_bytes) = bls_generate_blinded_g2_key(s);
@@ -230,10 +226,9 @@ pub extern "C" fn Java_bbs_signatures_Bbs_bls_1secret_1key_1to_1bbs_1key(
     }
     let sk = sk.unwrap();
     let (dpk, _) = DeterministicPublicKey::new(Some(KeyGenOption::FromSecretKey(sk)));
-    let pk;
-    match dpk.to_public_key(message_count as usize) {
+    let pk = match dpk.to_public_key(message_count as usize) {
         Err(_) => return bad_res,
-        Ok(p) => pk = p,
+        Ok(p) => p,
     };
     if pk.validate().is_err() {
         return bad_res;
@@ -259,25 +254,23 @@ pub extern "C" fn Java_bbs_signatures_Bbs_bls_1public_1key_1to_1bbs_1key(
     message_count: jint,
 ) -> jbyteArray {
     let bad_res = env.new_byte_array(0).unwrap();
-    let dpk;
-    match env.convert_byte_array(short_public_key) {
+    let dpk = match env.convert_byte_array(short_public_key) {
         Err(_) => return bad_res,
         Ok(s) => {
             if s.len() != DETERMINISTIC_PUBLIC_KEY_COMPRESSED_SIZE {
                 return bad_res;
             }
-            dpk = DeterministicPublicKey::from(*array_ref![
+            DeterministicPublicKey::from(*array_ref![
                 s,
                 0,
                 DETERMINISTIC_PUBLIC_KEY_COMPRESSED_SIZE
-            ]);
+            ])
         }
-    }
-    let pk;
-    match dpk.to_public_key(message_count as usize) {
+    };
+    let pk = match dpk.to_public_key(message_count as usize) {
         Err(_) => return bad_res,
-        Ok(p) => pk = p,
-    }
+        Ok(p) => p,
+    };
     if pk.validate().is_err() {
         return bad_res;
     }
@@ -767,15 +760,13 @@ pub extern "C" fn Java_bbs_signatures_Bbs_bbs_1unblind_1signature(
     unblind_signature: jbyteArray,
 ) -> jint {
     let mut err = ExternError::success();
-    let bs;
-    match env.convert_byte_array(blind_signature) {
+    let bs = match env.convert_byte_array(blind_signature) {
         Err(_) => return 1,
-        Ok(s) => bs = s,
+        Ok(s) => s,
     };
-    let bf;
-    match env.convert_byte_array(blinding_factor) {
+    let bf = match env.convert_byte_array(blinding_factor) {
         Err(_) => return 1,
-        Ok(s) => bf = s,
+        Ok(s) => s,
     };
 
     let mut signature = ByteBuffer::default();


### PR DESCRIPTION
Fixes clippy warnings and a problem that blocked Android build.

## Description

Clippy warnings were causing the master branch to fail. All pull requests from Dependabot also fail. I used `cargo clippy --fix` and fixed other warnings manually. 

The build_android job was also failing. Seemed to be because the NDK inside the Github Action is using a new version. The job now uses [https://github.com/nttld/setup-ndk](setup-ndk) action to install [r21e](https://github.com/nttld/setup-ndk). The Rust Android tool chain is compatible with version 21 (and 21 was already specified in the build.sh script).

- [x] ~Tests for the changes have been added (for bug fixes / features)~
- [x] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] Changes follow the **[contributing](../docs/contributing.md)** document.

## Motivation and Context

All our GitHub checks need to pass and this will fix them.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Which merge strategy will you use?

<!-- This indicates to reviewers whether they need to check your commits are ready to be rebased on master or not. -->

- [ ] Squash
- [x] Rebase (REVIEW COMMITS)
