### PR TITLE
chore: pin github actions versions

### DIFF
--- a/.github/workflows/ci-dotnet.yml
+++ b/.github/workflows/ci-dotnet.yml
@@ -67,7 +67,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: nttld/setup-ndk@v1
+      - uses: nttld/setup-ndk@b2abc75192ee2a1ec118c8238fd86dec6d96dc43 # pin@v1.0.6
         id: setup-ndk
         with:
           ndk-version: r21e
@@ -93,7 +93,7 @@ jobs:
           [xml]$projectFile = Get-Content ./wrappers/dotnet/Directory.Build.props
           $projectFile.Project.PropertyGroup[0].Version = if ($manualVersion) { $manualVersion } else { $packageVersion }
           $projectFile.Save("./wrappers/dotnet/Directory.Build.props")
-      - uses: microsoft/setup-msbuild@v1.0.2
+      - uses: microsoft/setup-msbuild@c26a08ba26249b81327e26f6ef381897b6a8754d # pin@v1.0.2
       - run: msbuild /t:restore,build /p:Configuration=Release ./wrappers/dotnet/
       - run: dotnet test -c Release ./wrappers/dotnet/src/BbsSignatures.Tests/
       - run: msbuild /t:restore,build,pack /p:Configuration=Release /p:Bbs_CopyLibsForProjectReference=false ./wrappers/dotnet/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         run: cargo clippy --all-targets --all-features -- -D warnings
 
       - name: Set up Android NDK
-        uses: nttld/setup-ndk@v1
+        uses: nttld/setup-ndk@b2abc75192ee2a1ec118c8238fd86dec6d96dc43 # pin@v1.0.6
         id: setup-ndk
         with:
           ndk-version: r21e

--- a/.github/workflows/github_backup.yaml
+++ b/.github/workflows/github_backup.yaml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@05b148adc31e091bafbaf404f745055d4d3bc9d2 # pin @v1.6.1
         with:
           aws-region: ap-southeast-2
           role-to-assume: arn:aws:iam::817632051851:role/oidc-github-actions-mattrglobal-global
@@ -22,7 +22,7 @@ jobs:
           role-session-name: GithubActions
 
       - name: Backing up this repo to AWS S3
-        uses: peter-evans/s3-backup@v1
+        uses: peter-evans/s3-backup@4f39c7dab63c7666d6ba6722d7966e7d0655583c # pin @v1.1.0
         env:
           AWS_REGION: ${{ env.AWS_REGION }}
           ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
As part of the preparation for the Trail of Bits audit we are pinning all non GitHub owned actions.

## Description

Pinning:
- configure-aws-credentials to v1.6.1 with this [commit](https://github.com/aws-actions/configure-aws-credentials/commit/05b148adc31e091bafbaf404f745055d4d3bc9d2)
- s3-backup to v1.1.0 with this [commit](https://github.com/peter-evans/s3-backup/commit/4f39c7dab63c7666d6ba6722d7966e7d0655583c)
- setup-ndk to v1.0.6 with this [commit](https://github.com/nttld/setup-ndk/commit/b2abc75192ee2a1ec118c8238fd86dec6d96dc43)
- setup-msbuild to v1.0.2 with this [commit](https://github.com/microsoft/setup-msbuild/commit/c26a08ba26249b81327e26f6ef381897b6a8754d)

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] Changes follow the **[contributing](../docs/CONTRIBUTING.md)** document.

## Motivation and Context

[DXM-854](https://mattrglobal.atlassian.net/jira/software/c/projects/DXM/boards/49?modal=detail&selectedIssue=DXM-854)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Which merge strategy will you use?

- [x] Squash
- [ ] Rebase (REVIEW COMMITS)