### PR TITLE
Make the java wrapper working on linux and windows

### DIFF
--- a/src/java.rs
+++ b/src/java.rs
@@ -14,39 +14,67 @@ use jni::sys::{jbyte, jbyteArray, jint, jlong};
 
 use crate::bbs_blind_commitment::{
     bbs_blind_commitment_context_add_message_bytes,
-    bbs_blind_commitment_context_add_message_prehashed, bbs_blind_commitment_context_finish,
-    bbs_blind_commitment_context_init, bbs_blind_commitment_context_set_nonce_bytes,
-    bbs_blind_commitment_context_set_public_key, bbs_blind_signature_size,
+    bbs_blind_commitment_context_add_message_prehashed,
+    bbs_blind_commitment_context_finish,
+    bbs_blind_commitment_context_init,
+    bbs_blind_commitment_context_set_nonce_bytes,
+    bbs_blind_commitment_context_set_public_key,
+    bbs_blind_signature_size,
 };
 use crate::bbs_blind_sign::{
-    bbs_blind_sign_context_add_message_bytes, bbs_blind_sign_context_add_message_prehashed,
-    bbs_blind_sign_context_finish, bbs_blind_sign_context_init,
-    bbs_blind_sign_context_set_commitment, bbs_blind_sign_context_set_public_key,
-    bbs_blind_sign_context_set_secret_key, bbs_blinding_factor_size, bbs_unblind_signature,
+    bbs_blind_sign_context_add_message_bytes,
+    bbs_blind_sign_context_add_message_prehashed,
+    bbs_blind_sign_context_finish,
+    bbs_blind_sign_context_init,
+    bbs_blind_sign_context_set_commitment,
+    bbs_blind_sign_context_set_public_key,
+    bbs_blind_sign_context_set_secret_key,
+    bbs_blinding_factor_size,
+    bbs_unblind_signature,
 };
 use crate::bbs_create_proof::{
-    CREATE_PROOF_CONTEXT,
-    bbs_create_proof_context_add_proof_message_bytes, bbs_create_proof_context_finish,
-    bbs_create_proof_context_init, bbs_create_proof_context_set_nonce_bytes,
+    bbs_create_proof_context_add_proof_message_bytes,
+    bbs_create_proof_context_finish,
+    bbs_create_proof_context_init,
+    bbs_create_proof_context_set_nonce_bytes,
     bbs_create_proof_context_set_signature,
     bbs_create_proof_context_size,
+    bbs_create_proof_context_set_public_key
 };
 use crate::bbs_sign::*;
 use crate::bbs_verify_proof::{
-    VERIFY_PROOF_CONTEXT,
-    bbs_verify_proof_context_add_message_bytes, bbs_verify_proof_context_add_message_prehashed,
-    bbs_verify_proof_context_finish, bbs_verify_proof_context_init,
-    bbs_verify_proof_context_set_nonce_bytes, bbs_verify_proof_context_set_proof,
+    bbs_verify_proof_context_add_message_bytes,
+    bbs_verify_proof_context_add_message_prehashed,
+    bbs_verify_proof_context_finish,
+    bbs_verify_proof_context_init,
+    bbs_verify_proof_context_set_nonce_bytes,
+    bbs_verify_proof_context_set_proof,
+    bbs_verify_proof_context_set_public_key
 };
-use crate::bls::{bls_public_key_g1_size, bls_public_key_g2_size, bls_secret_key_size};
+use crate::bls::{
+    bls_public_key_g1_size,
+    bls_public_key_g2_size,
+    bls_secret_key_size
+};
 use crate::*;
 use crate::{
-    bls_generate_blinded_g1_key, bls_generate_blinded_g2_key, bls_generate_g1_key,
+    bls_generate_blinded_g1_key,
+    bls_generate_blinded_g2_key,
+    bls_generate_g1_key,
     bls_generate_g2_key,
 };
-use bbs::keys::{DeterministicPublicKey, KeyGenOption, SecretKey, DETERMINISTIC_PUBLIC_KEY_COMPRESSED_SIZE, PublicKey};
-use bbs::{ToVariableLengthBytes, FR_COMPRESSED_SIZE, G1_COMPRESSED_SIZE};
-
+use bbs::keys::{
+    DeterministicPublicKey,
+    KeyGenOption,
+    SecretKey,
+    DETERMINISTIC_PUBLIC_KEY_COMPRESSED_SIZE,
+    PublicKey
+};
+use bbs::{
+    ToVariableLengthBytes,
+    FR_COMPRESSED_SIZE,
+    G1_COMPRESSED_SIZE
+};
 use std::cell::RefCell;
 
 thread_local! {
@@ -171,7 +199,7 @@ pub extern "C" fn Java_bbs_signatures_Bbs_bls_1generate_1blinded_1g1_1key(
     public_key: jbyteArray,
     secret_key: jbyteArray,
 ) -> jint {
-    let ikm =match env.convert_byte_array(seed) {
+    let ikm = match env.convert_byte_array(seed) {
         Err(_) => return 1,
         Ok(s) => s,
     };
@@ -308,7 +336,7 @@ pub extern "C" fn Java_bbs_signatures_Bbs_bbs_1sign_1set_1secret_1key(
                 2
             } else {
                 let mut error = ExternError::success();
-                let byte_array = ByteArray::from(s);
+                let byte_array = ByteArray::from(&s);
                 bbs_sign_context_set_secret_key(handle as u64, byte_array, &mut error)
             }
         }
@@ -350,7 +378,7 @@ pub extern "C" fn Java_bbs_signatures_Bbs_bbs_1sign_1add_1message_1bytes(
         Err(_) => 1,
         Ok(s) => {
             let mut error = ExternError::success();
-            let byte_array = ByteArray::from(s);
+            let byte_array = ByteArray::from(&s);
             bbs_sign_context_add_message_bytes(handle as u64, byte_array, &mut error)
         }
     }
@@ -368,7 +396,7 @@ pub extern "C" fn Java_bbs_signatures_Bbs_bbs_1sign_1add_1message_1prehashed(
         Err(_) => 1,
         Ok(s) => {
             let mut error = ExternError::success();
-            let byte_array = ByteArray::from(s);
+            let byte_array = ByteArray::from(&s);
             bbs_sign_context_add_message_prehashed(handle as u64, byte_array, &mut error)
         }
     }
@@ -412,7 +440,7 @@ pub extern "C" fn Java_bbs_signatures_Bbs_bbs_1verify_1add_1message_1bytes(
         Err(_) => 1,
         Ok(s) => {
             let mut error = ExternError::success();
-            let byte_array = ByteArray::from(s);
+            let byte_array = ByteArray::from(&s);
             bbs_verify_context_add_message_bytes(handle as u64, byte_array, &mut error)
         }
     }
@@ -430,7 +458,7 @@ pub extern "C" fn Java_bbs_signatures_Bbs_bbs_1verify_1add_1message_1prehashed(
         Err(_) => 1,
         Ok(s) => {
             let mut error = ExternError::success();
-            let byte_array = ByteArray::from(s);
+            let byte_array = ByteArray::from(&s);
             bbs_verify_context_add_message_prehashed(handle as u64, byte_array, &mut error)
         }
     }
@@ -448,7 +476,7 @@ pub extern "C" fn Java_bbs_signatures_Bbs_bbs_1verify_1set_1public_1key(
         Err(_) => 1,
         Ok(s) => {
             let mut error = ExternError::success();
-            let byte_array = ByteArray::from(s);
+            let byte_array = ByteArray::from(&s);
             bbs_verify_context_set_public_key(handle as u64, byte_array, &mut error)
         }
     }
@@ -469,7 +497,7 @@ pub extern "C" fn Java_bbs_signatures_Bbs_bbs_1verify_1set_1signature(
                 2
             } else {
                 let mut error = ExternError::success();
-                let byte_array = ByteArray::from(s);
+                let byte_array = ByteArray::from(&s);
                 bbs_verify_context_set_signature(handle as u64, byte_array, &mut error)
             }
         }
@@ -510,7 +538,7 @@ pub extern "C" fn Java_bbs_signatures_Bbs_bbs_1blind_1commitment_1add_1message_1
         Err(_) => 1,
         Ok(s) => {
             let mut error = ExternError::success();
-            let byte_array = ByteArray::from(s);
+            let byte_array = ByteArray::from(&s);
             bbs_blind_commitment_context_add_message_bytes(
                 handle as u64,
                 index as u32,
@@ -534,7 +562,7 @@ pub extern "C" fn Java_bbs_signatures_Bbs_bbs_1blind_1commitment_1add_1prehashed
         Err(_) => 1,
         Ok(s) => {
             let mut error = ExternError::success();
-            let byte_array = ByteArray::from(s);
+            let byte_array = ByteArray::from(&s);
             bbs_blind_commitment_context_add_message_prehashed(
                 handle as u64,
                 index as u32,
@@ -557,7 +585,7 @@ pub extern "C" fn Java_bbs_signatures_Bbs_bbs_1blind_1commitment_1set_1public_1k
         Err(_) => 1,
         Ok(s) => {
             let mut error = ExternError::success();
-            let byte_array = ByteArray::from(s);
+            let byte_array = ByteArray::from(&s);
             bbs_blind_commitment_context_set_public_key(handle as u64, byte_array, &mut error)
         }
     }
@@ -575,7 +603,7 @@ pub extern "C" fn Java_bbs_signatures_Bbs_bbs_1blind_1commitment_1set_1nonce_1by
         Err(_) => 1,
         Ok(s) => {
             let mut error = ExternError::success();
-            let byte_array = ByteArray::from(s);
+            let byte_array = ByteArray::from(&s);
             bbs_blind_commitment_context_set_nonce_bytes(handle as u64, byte_array, &mut error)
         }
     }
@@ -640,7 +668,7 @@ pub extern "C" fn Java_bbs_signatures_Bbs_bbs_1blind_1sign_1set_1secret_1key(
                 2
             } else {
                 let mut error = ExternError::success();
-                let byte_array = ByteArray::from(s);
+                let byte_array = ByteArray::from(&s);
                 bbs_blind_sign_context_set_secret_key(handle as u64, byte_array, &mut error)
             }
         }
@@ -659,7 +687,7 @@ pub extern "C" fn Java_bbs_signatures_Bbs_bbs_1blind_1sign_1set_1public_1key(
         Err(_) => 1,
         Ok(s) => {
             let mut error = ExternError::success();
-            let byte_array = ByteArray::from(s);
+            let byte_array = ByteArray::from(&s);
             bbs_blind_sign_context_set_public_key(handle as u64, byte_array, &mut error)
         }
     }
@@ -677,7 +705,7 @@ pub extern "C" fn Java_bbs_signatures_Bbs_bbs_1blind_1sign_1set_1commitment(
         Err(_) => 1,
         Ok(s) => {
             let mut error = ExternError::success();
-            let byte_array = ByteArray::from(s);
+            let byte_array = ByteArray::from(&s);
             bbs_blind_sign_context_set_commitment(handle as u64, byte_array, &mut error)
         }
     }
@@ -696,7 +724,7 @@ pub extern "C" fn Java_bbs_signatures_Bbs_bbs_1blind_1sign_1add_1message_1bytes(
         Err(_) => 1,
         Ok(s) => {
             let mut error = ExternError::success();
-            let byte_array = ByteArray::from(s);
+            let byte_array = ByteArray::from(&s);
             bbs_blind_sign_context_add_message_bytes(
                 handle as u64,
                 index as u32,
@@ -720,7 +748,7 @@ pub extern "C" fn Java_bbs_signatures_Bbs_bbs_1blind_1sign_1add_1prehashed(
         Err(_) => 1,
         Ok(s) => {
             let mut error = ExternError::success();
-            let byte_array = ByteArray::from(s);
+            let byte_array = ByteArray::from(&s);
             bbs_blind_sign_context_add_message_prehashed(
                 handle as u64,
                 index as u32,
@@ -771,8 +799,8 @@ pub extern "C" fn Java_bbs_signatures_Bbs_bbs_1unblind_1signature(
 
     let mut signature = ByteBuffer::default();
     let res = bbs_unblind_signature(
-        ByteArray::from(bs),
-        ByteArray::from(bf),
+        ByteArray::from(&bs),
+        ByteArray::from(&bf),
         &mut signature,
         &mut err,
     );
@@ -810,15 +838,8 @@ pub extern "C" fn Java_bbs_signatures_Bbs_bbs_1create_1proof_1context_1set_1publ
         Err(_) => 1,
         Ok(s) => {
             let mut error = ExternError::success();
-            // let byte_array = ByteArray::from(s.clone());
-            // bbs_create_proof_context_set_public_key(handle as u64, byte_array, &mut error)
-            CREATE_PROOF_CONTEXT.call_with_result_mut(&mut error, handle as u64, |ctx| -> Result<(), BbsFfiError> {
-                use std::convert::TryFrom;
-                let v = PublicKey::try_from(s)?;
-                ctx.public_key = Some(v);
-                Ok(())
-            });
-            error.get_code().code()
+            let byte_array = ByteArray::from(&s);
+            bbs_create_proof_context_set_public_key(handle as u64, byte_array, &mut error)
         }
     }
 }
@@ -835,7 +856,7 @@ pub extern "C" fn Java_bbs_signatures_Bbs_bbs_1create_1proof_1context_1set_1sign
         Err(_) => 1,
         Ok(s) => {
             let mut error = ExternError::success();
-            let byte_array = ByteArray::from(s);
+            let byte_array = ByteArray::from(&s);
             let res = bbs_create_proof_context_set_signature(handle as u64, byte_array, &mut error);
             if res != 0 {
                 update_last_error(error.get_message().as_str());
@@ -857,7 +878,7 @@ pub extern "C" fn Java_bbs_signatures_Bbs_bbs_1create_1proof_1context_1set_1nonc
         Err(_) => 1,
         Ok(s) => {
             let mut error = ExternError::success();
-            let byte_array = ByteArray::from(s);
+            let byte_array = ByteArray::from(&s);
             bbs_create_proof_context_set_nonce_bytes(handle as u64, byte_array, &mut error)
         }
     }
@@ -877,7 +898,7 @@ pub extern "C" fn Java_bbs_signatures_Bbs_bbs_1create_1proof_1context_1add_1proo
         Err(_) => 1,
         Ok(s) => {
             let mut error = ExternError::success();
-            let byte_array = ByteArray::from(s);
+            let byte_array = ByteArray::from(&s);
             let mut bf_byte_array = ByteArray::default();
             let proof_msg_type = match xtype {
                 1 => ProofMessageType::Revealed,
@@ -886,7 +907,7 @@ pub extern "C" fn Java_bbs_signatures_Bbs_bbs_1create_1proof_1context_1add_1proo
                     match env.convert_byte_array(blinding_factor) {
                         Err(_) => return 0,
                         Ok(bf) => {
-                            bf_byte_array = ByteArray::from(bf);
+                            bf_byte_array = ByteArray::from(&bf);
                         }
                     };
                     ProofMessageType::HiddenExternalBlinding
@@ -952,7 +973,7 @@ pub extern "C" fn Java_bbs_signatures_Bbs_bbs_1verify_1proof_1context_1add_1mess
         Err(_) => 1,
         Ok(s) => {
             let mut error = ExternError::success();
-            let byte_array = ByteArray::from(s);
+            let byte_array = ByteArray::from(&s);
             bbs_verify_proof_context_add_message_bytes(
                 handle as u64,
                 byte_array,
@@ -974,7 +995,7 @@ pub extern "C" fn Java_bbs_signatures_Bbs_bbs_1verify_1proof_1context_1add_1mess
         Err(_) => 1,
         Ok(s) => {
             let mut error = ExternError::success();
-            let byte_array = ByteArray::from(s);
+            let byte_array = ByteArray::from(&s);
             bbs_verify_proof_context_add_message_prehashed(
                 handle as u64,
                 byte_array,
@@ -1018,15 +1039,8 @@ pub extern "C" fn Java_bbs_signatures_Bbs_bbs_1verify_1proof_1context_1set_1publ
         Err(_) => 1,
         Ok(s) => {
             let mut error = ExternError::success();
-            // let byte_array = ByteArray::from(s);
-            // bbs_verify_proof_context_set_public_key(handle as u64, byte_array, &mut error)
-            VERIFY_PROOF_CONTEXT.call_with_result_mut(&mut error, handle as u64, |ctx| -> Result<(), BbsFfiError> {
-                use std::convert::TryFrom;
-                let v = PublicKey::try_from(s)?;
-                ctx.public_key = Some(v);
-                Ok(())
-            });
-            error.get_code().code()
+            let byte_array = ByteArray::from(&s);
+            bbs_verify_proof_context_set_public_key(handle as u64, byte_array, &mut error)
         }
     }
 }
@@ -1043,7 +1057,7 @@ pub extern "C" fn Java_bbs_signatures_Bbs_bbs_1verify_1proof_1context_1set_1nonc
         Err(_) => 1,
         Ok(s) => {
             let mut error = ExternError::success();
-            let byte_array = ByteArray::from(s);
+            let byte_array = ByteArray::from(&s);
             bbs_verify_proof_context_set_nonce_bytes(handle as u64, byte_array, &mut error)
         }
     }

--- a/wrappers/java/build.gradle
+++ b/wrappers/java/build.gradle
@@ -17,14 +17,14 @@ plugins {
 group 'com.github.mattrglobal'
 version '1.6-SNAPSHOT'
 
-apply plugin : "java" 
+apply plugin: "java"
 apply plugin: "maven-publish"
 apply plugin: 'signing'
 
 ext {
-   javaMainClass = "bbs.signatures.Bbs"
+    javaMainClass = "bbs.signatures.Bbs"
 }
- 
+
 application {
     mainClassName = javaMainClass
 }
@@ -46,22 +46,53 @@ dependencies {
     testImplementation 'junit:junit:4.13'
 }
 
+build {
+    dependsOn ':copyWindowsBinaries'
+    dependsOn ':copyLinuxBinaries'
+}
+
+task copyWindowsBinaries(type: Copy) {
+    dependsOn ':buildWindowsBinaries'
+    from "../../target/x86_64-pc-windows-gnu/release/bbs.dll"
+    into "src/main/jniLibs/windows"
+}
+
+task buildWindowsBinaries(type: Exec) {
+    workingDir "${projectDir}"
+    commandLine 'rustup', 'target', 'add', 'x86_64-pc-windows-gnu'
+    commandLine 'cargo', 'build', '--target', 'x86_64-pc-windows-gnu', '--release', '--features', 'java'
+}
+
+task copyLinuxBinaries(type: Copy) {
+    dependsOn ':buildLinuxBinaries'
+    from "../../target/x86_64-unknown-linux-gnu/release/libbbs.so"
+    into "src/main/jniLibs/linux"
+}
+
+task buildLinuxBinaries(type: Exec) {
+    workingDir "${projectDir}"
+    commandLine 'rustup', 'target', 'add', 'x86_64-unknown-linux-gnu'
+    commandLine 'cargo', 'build', '--target', 'x86_64-unknown-linux-gnu', '--release', '--features', 'java'
+}
+
+
+
 // Builds all the available binaries
 // given the current host
-task buildAndroidBinaries(type:Exec) {  
+task buildAndroidBinaries(type: Exec) {
     workingDir '../../'
 
     // Builds the Android Binaries
-    commandLine './scripts/build.sh' , 'ANDROID' , 'out'
+    commandLine './scripts/build.sh', 'ANDROID', 'out'
 }
 
 // Builds all the available binaries
 // given the current host
-task buildMacosBinaries(type:Exec) {  
+task buildMacosBinaries(type: Exec) {
     workingDir '../../'
 
     // Build MacOS Binaries (if on Mac)
-    commandLine './scripts/build.sh' , 'MACOS', 'out'
+    commandLine './scripts/build.sh', 'MACOS', 'out'
 }
 
 // Builds and copies the required binaries for the java wrapper
@@ -71,7 +102,7 @@ task buildBinaries {
 }
 
 // Copies the android binaries to the JNI libraries folder
-task copyAndroidBinaries(type:Exec) {
+task copyAndroidBinaries(type: Exec) {
     workingDir '../../'
 
     //on linux
@@ -79,9 +110,9 @@ task copyAndroidBinaries(type:Exec) {
 }
 
 // Copies the android binaries to the JNI libraries folder
-task copyMacosBinaries(type:Exec) {
+task copyMacosBinaries(type: Exec) {
     workingDir '../../'
-    
+
     //on macos
     commandLine 'cp', '-r', 'out/macos/', 'wrappers/java/src/main/jniLibs/'
 }
@@ -104,17 +135,27 @@ task copyMacosNativeDep(type: Copy) {
     into 'build/libs'
 }
 
-/* Test with JUNIT on Macos */
+/* Test with JUNIT on different platform (windows, linux, ...) */
 test {
-    dependsOn copyMacosNativeDep
-    systemProperty "java.library.path", 'build/libs'
+    if (org.gradle.internal.os.OperatingSystem.current().isWindows()) {
+        dependsOn ':copyWindowsBinaries'
+        systemProperty "java.library.path", 'src/main/jniLibs/windows'
+        useJUnit()
+    } else if (org.gradle.internal.os.OperatingSystem.current().isLinux()){
+        dependsOn ':copyLinuxBinaries'
+        systemProperty "java.library.path", 'src/main/jniLibs/linux'
+        useJUnit()
+    } else {
+        dependsOn ':copyMacosNativeDep'
+        systemProperty "java.library.path", 'build/libs'
 
-    useJUnit()
+        useJUnit()
 
-    maxHeapSize = '1G'
-    
-    // Enable logging output to stderr
-    testLogging.showStandardStreams = true
+        maxHeapSize = '1G'
+
+        // Enable logging output to stderr
+        testLogging.showStandardStreams = true
+    }
 }
 
 task runMain(type: JavaExec) {
@@ -126,8 +167,8 @@ task runMain(type: JavaExec) {
 }
 
 task sourceJar(type: Jar) {
-  from sourceSets.main.allJava
-  archiveClassifier = "sources"
+    from sourceSets.main.allJava
+    archiveClassifier = "sources"
 }
 
 jar {

--- a/wrappers/java/gradle/wrapper/gradle-wrapper.properties
+++ b/wrappers/java/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/wrappers/java/src/test/java/bbs/signatures/BbsSignatureTest.java
+++ b/wrappers/java/src/test/java/bbs/signatures/BbsSignatureTest.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.HashMap;
 import java.util.Base64;
+import java.util.Random;
 
 import static org.junit.Assert.*;
 
@@ -174,11 +175,17 @@ public class BbsSignatureTest {
     public void canVerifyMessage() {
         KeyPair keyPair = getBls12381G2KeyPair();
 
-        byte[][] messages = {"message1".getBytes()};
+        int numberOfMessages = 200;
+        byte[][] messages = new byte[numberOfMessages][200];
+        Random random = new Random();
+        for (int i = 0; i < numberOfMessages; i++) {
+            random.nextBytes(messages[i]);
+        }
+
         byte[] bbsKey = Bbs.blsPublicToBbsPublicKey(keyPair.publicKey, messages.length);
         byte[] secretKey = keyPair.secretKey;
 
-        byte[] signature = new byte[Bbs.getSignatureSize()];
+        byte[] signature = null;
 
         try {
             signature = Bbs.sign(secretKey, bbsKey, messages);
@@ -204,9 +211,15 @@ public class BbsSignatureTest {
         KeyPair keyPair = getBls12381G2KeyPair();
         byte[] publicKey = keyPair.publicKey;
         byte[] secretKey = keyPair.secretKey;
-        byte[][] messages = {"message1".getBytes()};
 
-        byte[] signature = new byte[Bbs.getSignatureSize()];
+        int numberOfMessages = 200;
+        byte[][] messages = new byte[numberOfMessages][200];
+        Random random = new Random();
+        for (int i = 0; i < numberOfMessages; i++) {
+            random.nextBytes(messages[i]);
+        }
+
+        byte[] signature = null;
 
         try {
             signature = Bbs.blsSign(secretKey, publicKey, messages);


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above
-->

## Description

This pull request consists of 3 commits which make the existing java wrapper working for linux and windows targets.
- https://github.com/mattrglobal/ffi-bbs-signatures/commit/b91b04bf6ecd86ab3e6cdaedf33d9964981b88b0 adds build tasks to build the wrapper for linux. The build tasks install the necessary tool chain (using rustup), build the native lib (using cargo) and copy the built libs into the src folder. The test task is modified to allow testing on linux and windows platforms using the libs in the src folder.
- https://github.com/mattrglobal/ffi-bbs-signatures/commit/2a9680b6c6102c79db7636b39c0dd67b15bf20b9 modifies the tests to address signing and verifiying of large number of messages (e.g. required for signing vaccination credentials). The modified tests fail on windows if commit https://github.com/mattrglobal/ffi-bbs-signatures/commit/5cfe730ae7310067004da4734bd03f3cff1fc178 is not applied.
- https://github.com/mattrglobal/ffi-bbs-signatures/commit/5cfe730ae7310067004da4734bd03f3cff1fc178 fixes issues with invalid data due to loss of ownership. Instead of use of ByteArray::from(vec[8]) to create ByteArray ByteArray::from(&vec[8]) is used preventing move of ownership. The ownership remains in the calling scope and the data are not overwritten before used later in this scope.   

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] Changes follow the **[contributing](../docs/contributing.md)** document.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Make java wrapper available on linux and windows and fixes issues with invalid data when signing and verifying large number of messages. Signing and verifying large number of messages is required for jsonld data (e.g. verifiable credentials - [vaccination credentials](https://w3id.org/vaccination/v1) etc.).

[issue#43](https://github.com/mattrglobal/ffi-bbs-signatures/issues/43)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Which merge strategy will you use?

<!-- This indicates to reviewers whether they need to check your commits are ready to be rebased on master or not. -->

- [ ] Squash
- [x] Rebase (REVIEW COMMITS)
