### PR TITLE
fix: update pytest to latest

### DIFF
--- a/wrappers/python/Pipfile
+++ b/wrappers/python/Pipfile
@@ -6,7 +6,7 @@ name = "pypi"
 [packages]
 
 [dev-packages]
-pytest = "==6.2.5"
+pytest = "==7.4.2"
 
 [requires]
 python_version = "3.9"

--- a/wrappers/python/Pipfile.lock
+++ b/wrappers/python/Pipfile.lock
@@ -1,7 +1,7 @@
 {
   "_meta": {
     "hash": {
-      "sha256": "0790158ff03d89dccb648de641fd0130cc5ea53f3de3f2e351a23bc62495659a"
+      "sha256": "b3d4e8d5d4f3ff5355290d7ccd51e0c035cf0dd48b18df7468c4988883be9081"
     },
     "pipfile-spec": 6,
     "requires": {
@@ -17,10 +17,10 @@
   },
   "default": {},
   "develop": {
-    "attrs": {
+    "exceptiongroup": {
       "hashes": [
-        "sha256:1f28b4522cdc2fb4256ac1a020c78acf9cba2c6b461ccd2c126f3aa8e8335d04",
-        "sha256:6279836d581513a26f1bf235f9acd333bc9115683f14f7e8fae46c98fc50e015"
+        "sha256:097acd85d473d75af5bb98e41b61ff7fe35efe6675e4f9370ec6ec5126d160e9",
+        "sha256:343280667a4585d195ca1cf9cef84a4e178c4b6cf2274caef9859782b567d5e3"
       ],
       "markers": "python_version >= '3.7'",
       "version": "==23.1.0"
@@ -49,30 +49,22 @@
       "markers": "python_version >= '3.8'",
       "version": "==1.3.0"
     },
-    "py": {
-      "hashes": [
-        "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719",
-        "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"
-      ],
-      "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-      "version": "==1.11.0"
-    },
     "pytest": {
       "hashes": [
-        "sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89",
-        "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"
+        "sha256:1d881c6124e08ff0a1bb75ba3ec0bfd8b5354a01c194ddd5a0a870a48d99b002",
+        "sha256:a766259cfab564a2ad52cb1aae1b881a75c3eb7e34ca3779697c23ed47c47069"
       ],
       "index": "pypi",
-      "markers": "python_version >= '3.6'",
-      "version": "==6.2.5"
+      "markers": "python_version >= '3.7'",
+      "version": "==7.4.2"
     },
-    "toml": {
+    "tomli": {
       "hashes": [
-        "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
-        "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+        "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
+        "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
       ],
-      "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-      "version": "==0.10.2"
+      "markers": "python_version < '3.11'",
+      "version": "==2.0.1"
     }
   }
 }


### PR DESCRIPTION
## Description

Updates pytest to 7.4.2 which removes the `py` dependency, which I expect will resolve Dependabot [#26](https://github.com/mattrglobal/ffi-bbs-signatures/security/dependabot/26)

- [x] ~Tests for the changes have been added (for bug fixes / features)~
- [x] ~The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)~
- [x] ~Documentation has been added / updated (for bug fixes / features)~
- [x] ~Changes follow the **[contributing](../docs/contributing.md)** document.~

## Motivation and Context

Part of MATTR's push to close security alerts.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Which merge strategy will you use?

<!-- This indicates to reviewers whether they need to check your commits are ready to be rebased on master or not. -->

- [x] Squash
- [ ] Rebase (REVIEW COMMITS)
