### PR TITLE
fix: disable dotnet and java workflows

### DIFF
--- a/.github/workflows/ci-dotnet.yml
+++ b/.github/workflows/ci-dotnet.yml
@@ -20,6 +20,7 @@ concurrency:
 
 jobs:
   build_windows:
+    if: false
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v1
@@ -34,6 +35,7 @@ jobs:
           path: ./out/windows/*
 
   build_linux:
+    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
@@ -44,6 +46,7 @@ jobs:
           path: ./out/linux/*
 
   build_macos:
+    if: false
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v1
@@ -54,6 +57,7 @@ jobs:
           path: ./out/macos/darwin-x86_64/*
 
   build_ios:
+    if: false
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v1
@@ -64,6 +68,7 @@ jobs:
           path: ./out/ios/*
 
   build_android:
+    if: false
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v1
@@ -82,6 +87,7 @@ jobs:
           path: ./out/android/*
 
   package_nuget:
+    if: false
     runs-on: windows-latest
     needs: [build_windows, build_macos, build_linux, build_android, build_ios]
     steps:

--- a/.github/workflows/ci-java.yml
+++ b/.github/workflows/ci-java.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   build_test:
     name: Build & Test Java Wrapper
-    if: "! contains(github.event.head_commit.message, '[skip ci]')"
+    if: "! contains(github.event.head_commit.message, '[skip ci]') && false"
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Disable .NET and Java builds as a temporary measure.

## Description

Unfortunately these two builds no longer function. I recently merged changes that close four security alerts. Since the .NET and Java builds are broken (due to downstream projects, environmental changes) I need to disable them to release my work. We'll look at restoring them at a later stage.

- [ ] ~Tests for the changes have been added (for bug fixes / features)~
- [x] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] Changes follow the **[contributing](../docs/contributing.md)** document.

## Motivation and Context

These builds have been broken for a while. It's hard to say what has happened. Need to disable them until we diagnose the problems and can get a fix ready.

[#](https://github.com/mattrglobal/ffi-bbs-signatures/issues/)

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

Will put a note in the CHANGELOG.md about this.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Which merge strategy will you use?

<!-- This indicates to reviewers whether they need to check your commits are ready to be rebased on master or not. -->

- [x] Squash
- [ ] Rebase (REVIEW COMMITS)
