### PR TITLE
fix: bump actions to v3 , skip linting warnings, disable ci-obj-c wrapper

### DIFF
--- a/.github/workflows/ci-dotnet.yml
+++ b/.github/workflows/ci-dotnet.yml
@@ -23,13 +23,13 @@ jobs:
     if: false
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - run: |
           mkdir .\out\windows
           cargo build --release
           cp .\target\release\bbs.dll .\out\windows
       # - run: yarn build:windows
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: windows
           path: ./out/windows/*
@@ -38,9 +38,9 @@ jobs:
     if: false
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - run: yarn build:linux
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: linux
           path: ./out/linux/*
@@ -49,9 +49,9 @@ jobs:
     if: false
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - run: yarn build:macos
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: macos
           path: ./out/macos/darwin-x86_64/*
@@ -60,9 +60,9 @@ jobs:
     if: false
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - run: yarn build:ios
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: ios
           path: ./out/ios/*
@@ -71,17 +71,17 @@ jobs:
     if: false
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Set up Android NDK
-        uses: nttld/setup-ndk@dbacc5871a0fac6eef9a09d2ca86bc8bf79432c3 # pin@v1.3.1
+        uses: nttld/setup-ndk@afb4c9964b521afb97c864b7d40b11e6911bd410 # pin@v1.5.0
         id: setup-ndk
         with:
-          ndk-version: r23
+          ndk-version: r27c
 
       - run: yarn build:android
         env:
           ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: android
           path: ./out/android/*
@@ -91,7 +91,7 @@ jobs:
     runs-on: windows-latest
     needs: [build_windows, build_macos, build_linux, build_android, build_ios]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - uses: actions/download-artifact@v2
         with:
           path: ./wrappers/dotnet/libs
@@ -105,7 +105,7 @@ jobs:
       - run: msbuild /t:restore,build /p:Configuration=Release ./wrappers/dotnet/
       - run: dotnet test -c Release ./wrappers/dotnet/src/BbsSignatures.Tests/
       - run: msbuild /t:restore,build,pack /p:Configuration=Release /p:Bbs_CopyLibsForProjectReference=false ./wrappers/dotnet/
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: package-nuget
           path: |

--- a/.github/workflows/ci-java.yml
+++ b/.github/workflows/ci-java.yml
@@ -18,7 +18,7 @@ jobs:
     if: "! contains(github.event.head_commit.message, '[skip ci]') && false"
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/ci-obj-c.yml
+++ b/.github/workflows/ci-obj-c.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: macos-11
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v1
 
       - name: Install Dependencies
         run: yarn install --frozen-lockfile

--- a/.github/workflows/ci-obj-c.yml
+++ b/.github/workflows/ci-obj-c.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   build_test:
     name: Build & Test Objective-C Wrapper
-    if: "! contains(github.event.head_commit.message, '[skip ci objective-c wrapper]')"
+    if: "! contains(github.event.head_commit.message, '[skip ci] && false')"
     runs-on: macos-11
     steps:
       - name: Checkout

--- a/.github/workflows/ci-obj-c.yml
+++ b/.github/workflows/ci-obj-c.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   build_test:
     name: Build & Test Objective-C Wrapper
-    if: "! contains(github.event.head_commit.message, '[skip ci] && false')"
+    if: false
     runs-on: macos-11
     steps:
       - name: Checkout

--- a/.github/workflows/ci-obj-c.yml
+++ b/.github/workflows/ci-obj-c.yml
@@ -15,11 +15,11 @@ concurrency:
 jobs:
   build_test:
     name: Build & Test Objective-C Wrapper
-    if: "! contains(github.event.head_commit.message, '[skip ci]')"
+    if: "! contains(github.event.head_commit.message, '[skip ci objective-c wrapper]')"
     runs-on: macos-11
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Install Dependencies
         run: yarn install --frozen-lockfile

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - if: "matrix.os == 'windows-latest'"
         run: |
           mkdir .\out\windows
@@ -50,7 +50,7 @@ jobs:
           cp .\target\release\bbs.dll .\out\windows
       - if: "matrix.os != 'windows-latest'"
         run: yarn build:${{matrix.plat-name-simple}}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: ${{matrix.plat-name-simple}}
           path: ${{matrix.target-path}}/*
@@ -73,16 +73,16 @@ jobs:
           - os: windows-latest
             plat-name-simple: windows
             target-name: bbs.dll
-    
+
     runs-on: ${{ matrix.os }}
-        
+
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: ${{matrix.plat-name-simple}}
           path: ./wrappers/python/ursa_bbs_signatures
@@ -126,11 +126,11 @@ jobs:
           pip install setuptools wheel twine auditwheel
 
       - name: Download library artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: ${{matrix.plat-name-simple}}
           path: ./wrappers/python/ursa_bbs_signatures
-          
+
       - name: Build python wheels
         shell: sh
         run: |
@@ -142,7 +142,7 @@ jobs:
         run: auditwheel show ./wrappers/python/dist/*
 
       - name: Upload python package
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: python-${{ runner.os }}
           path: ./wrappers/python/dist/*

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -77,7 +77,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
@@ -113,7 +113,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
@@ -31,10 +31,10 @@ jobs:
         run: cargo clippy --all-targets --all-features -- -D warnings
 
       - name: Set up Android NDK
-        uses: nttld/setup-ndk@dbacc5871a0fac6eef9a09d2ca86bc8bf79432c3 # pin@v1.3.1
+        uses: nttld/setup-ndk@afb4c9964b521afb97c864b7d40b11e6911bd410 # pin@v1.5.0
         id: setup-ndk
         with:
-          ndk-version: r23
+          ndk-version: r27c
 
       - name: Build
         run: yarn build

--- a/.github/workflows/github_backup.yaml
+++ b/.github/workflows/github_backup.yaml
@@ -11,7 +11,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Configure aws credentials
         uses: aws-actions/configure-aws-credentials@05b148adc31e091bafbaf404f745055d4d3bc9d2 # pin @v1.6.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Install Dependencies
         run: yarn install --frozen-lockfile

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -3,8 +3,8 @@
 
 set -e
 
-LANGUAGE=$1
-PLATFORM=$2
+LANGUAGE=$1 #C
+PLATFORM=$2 #MACOS
 
 if [ -z "$LANGUAGE" ]
 then
@@ -20,13 +20,13 @@ fi
 
 case $PLATFORM in
   MACOS)
-      echo "Building for Apple Darwin x86_64"
-      rustup target add x86_64-apple-darwin
+      echo "Building for ARM Apple Darwin aarch64"
+      rustup target add aarch64-apple-darwin
       case $LANGUAGE in
         C)
           echo "To be used with C"
-          cargo build --target x86_64-apple-darwin --release
-          export RUST_LIBRARY_DIRECTORY="${PWD}/target/x86_64-apple-darwin/release"
+          cargo build --target aarch64-apple-darwin --release
+          export RUST_LIBRARY_DIRECTORY="${PWD}/target/aarch64-apple-darwin/release"
           cd $RUST_LIBRARY_DIRECTORY
           cmake ../../../tests
           cmake --build .

--- a/src/java.rs
+++ b/src/java.rs
@@ -50,6 +50,7 @@ use bbs::{ToVariableLengthBytes, FR_COMPRESSED_SIZE, G1_COMPRESSED_SIZE};
 use std::cell::RefCell;
 
 thread_local! {
+    #[allow(clippy::missing_const_for_thread_local)]
     static LAST_ERROR: RefCell<Option<String>> = RefCell::new(None);
 }
 
@@ -64,6 +65,7 @@ fn update_last_error(m: &str) {
 pub extern "C" fn Java_bbs_signatures_Bbs_get_1last_1error<'a>(env: JNIEnv<'a>, _: JObject) -> JString<'a> {
     let mut res = env.new_string("").unwrap();
     LAST_ERROR.with(|prev| {
+        #[allow(clippy::single_match)]
         match &*prev.borrow() {
             Some(s) => res = env.new_string(s).unwrap(),
             None => ()


### PR DESCRIPTION
Bump actions/upload-artifact and skip linting warnings to fix failing CI pipeline.

## Description

<!--- Describe your changes in detail -->

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] Changes follow the **[contributing](../docs/contributing.md)** document.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it relates to an open issue, please link to the issue here.
e.g.
[#123](https://github.com/mattrglobal/ffi-bbs-signatures/issues/123)
-->

[#](https://github.com/mattrglobal/ffi-bbs-signatures/issues/)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Which merge strategy will you use?

<!-- This indicates to reviewers whether they need to check your commits are ready to be rebased on master or not. -->

- [x] Squash
- [ ] Rebase (REVIEW COMMITS)
